### PR TITLE
chore: add worktrees/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 *.pyc
 *.pyo
 .pytest_cache/
+worktrees/


### PR DESCRIPTION
## Summary
Standardize working directory ignore patterns by adding worktrees/ to gitignore.

## Changes
- Add worktrees/ to .gitignore

## Notes
- Part of breadth-first ecosystem evaluation
---
*Generated by breadth-first ecosystem evaluation*