### PR TITLE
feat: add arch_test crate with TDD, BDD, proptest patterns

### DIFF
--- a/crates/arch_test/Cargo.toml
+++ b/crates/arch_test/Cargo.toml
@@ -2,6 +2,7 @@
 name = "arch_test"
 version = "0.1.0"
 edition = "2021"
+description = "Architectural tests for heliosCLI - boundary enforcement, TDD patterns, property-based testing"
 
 [dependencies]
 proptest = "1.4"

--- a/crates/arch_test/src/boundary.rs
+++ b/crates/arch_test/src/boundary.rs
@@ -1,7 +1,17 @@
-//! Boundary enforcement tests
+//! Boundary enforcement tests for hexagonal architecture
+
 use std::path::Path;
+
+/// Layer in hexagonal architecture
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Layer { Domain, Application, Ports, Infrastructure, Adapters }
+pub enum Layer {
+    Domain,
+    Application,
+    Ports,
+    Infrastructure,
+    Adapters,
+}
+
 impl Layer {
     pub fn from_path(path: &Path) -> Option<Self> {
         let s = path.to_string_lossy();
@@ -12,6 +22,7 @@ impl Layer {
         else if s.contains("/adapters/") { Some(Layer::Adapters) }
         else { None }
     }
+    
     pub fn allowed(&self) -> Vec<Layer> {
         match self {
             Layer::Domain => vec![],
@@ -22,11 +33,39 @@ impl Layer {
         }
     }
 }
-pub struct BoundaryEnforcer { violations: Vec<(String, String)> }
-impl BoundaryEnforcer { pub fn new() -> Self { Self { violations: Vec::new() } } pub fn is_clean(&self) -> bool { self.violations.is_empty() } }
-impl Default for BoundaryEnforcer { fn default() -> Self::new() }
-#[cfg(test)] mod tests {
+
+/// Boundary enforcer
+pub struct BoundaryEnforcer {
+    violations: Vec<(String, String)>,
+}
+
+impl BoundaryEnforcer {
+    pub fn new() -> Self {
+        Self { violations: Vec::new() }
+    }
+    
+    pub fn is_clean(&self) -> bool {
+        self.violations.is_empty()
+    }
+}
+
+impl Default for BoundaryEnforcer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
     use super::*;
-    #[test] fn test_domain_layer() { assert!(Layer::from_path(Path::new("src/domain/model.rs")).is_some()); }
-    #[test] fn test_boundary_clean() { assert!(BoundaryEnforcer::new().is_clean()); }
+    
+    #[test]
+    fn test_domain_layer() {
+        assert!(Layer::from_path(Path::new("src/domain/model.rs")).is_some());
+    }
+    
+    #[test]
+    fn test_boundary_clean() {
+        assert!(BoundaryEnforcer::new().is_clean());
+    }
 }

--- a/crates/arch_test/src/lib.rs
+++ b/crates/arch_test/src/lib.rs
@@ -1,7 +1,14 @@
-//! # arch_test - Architectural Tests
+//! # arch_test - Architectural Tests for heliosCLI
+//!
+//! This crate provides architectural testing infrastructure including:
+//! - Boundary enforcement tests
+//! - TDD patterns (Red-Green-Refactor)
+//! - Property-based testing with proptest
+
 pub mod boundary;
 pub mod tdd;
 pub mod proptest_patterns;
+
 pub use boundary::BoundaryEnforcer;
 pub use tdd::TestDriven;
 pub use proptest_patterns::PropertyTest;

--- a/crates/arch_test/src/proptest_patterns.rs
+++ b/crates/arch_test/src/proptest_patterns.rs
@@ -1,18 +1,64 @@
-//! Property-based testing patterns
-#[derive(Debug, Clone)] pub struct PropertyTest { pub name: String, pub iterations: u32 }
-impl PropertyTest { pub fn new(name: impl Into<String>) -> Self { Self { name: name.into(), iterations: 256 } } }
-pub mod strategies {
-    use proptest::prelude::*;
-    pub fn valid_utf8() -> impl Strategy<Value = String> { ".*" }
-    pub fn positive_int() -> impl Strategy<Value = u32> { any::<u32>().prop_filter("positive", |&n| n > 0) }
-    pub fn identifier() -> impl Strategy<Value = String> { "[a-z][a-z0-9_]{0,63}" }
+//! Property-based testing patterns with proptest
+
+/// Property test configuration
+#[derive(Debug, Clone)]
+pub struct PropertyTest {
+    pub name: String,
+    pub iterations: u32,
 }
-pub mod invariants {
-    pub fn check<T>(value: &T, inv: impl Fn(&T) -> bool, name: &str) -> Result<(), String> {
-        if inv(value) { Ok(()) } else { Err(format!("Invariant violated: {}", name)) }
+
+impl PropertyTest {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            iterations: 256,
+        }
     }
 }
-#[cfg(test)] mod tests {
+
+/// Common strategies for property-based testing
+pub mod strategies {
+    use proptest::prelude::*;
+    
+    /// Strategy for valid UTF-8 strings
+    pub fn valid_utf8() -> impl Strategy<Value = String> {
+        ".*"
+    }
+    
+    /// Strategy for non-empty strings
+    pub fn non_empty_string() -> impl Strategy<Value = String> {
+        "[^\\s].*"
+    }
+    
+    /// Strategy for positive integers
+    pub fn positive_int() -> impl Strategy<Value = u32> {
+        any::<u32>().prop_filter("positive", |&n| n > 0)
+    }
+    
+    /// Strategy for valid identifiers
+    pub fn identifier() -> impl Strategy<Value = String> {
+        "[a-z][a-z0-9_]{0,63}"
+    }
+}
+
+/// Invariant checking
+pub mod invariants {
+    /// Check that an invariant holds
+    pub fn check<T>(value: &T, inv: impl Fn(&T) -> bool, name: &str) -> Result<(), String> {
+        if inv(value) {
+            Ok(())
+        } else {
+            Err(format!("Invariant violated: {}", name))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
     use super::*;
-    #[test] fn test_invariant() { assert!(invariants::check(&42, |v| *v > 0, "positive").is_ok()); }
+    
+    #[test]
+    fn test_invariant() {
+        assert!(invariants::check(&42, |v| *v > 0, "positive").is_ok());
+    }
 }

--- a/crates/arch_test/src/tdd.rs
+++ b/crates/arch_test/src/tdd.rs
@@ -1,27 +1,67 @@
-//! TDD patterns
-#[derive(Debug, Clone, Copy, PartialEq, Eq)] pub enum TddPhase { Red, Green, Refactor }
-pub struct TestDriven { phase: TddPhase, cycles: u32 }
+//! TDD patterns - Red-Green-Refactor cycle
+
+/// TDD phase
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TddPhase {
+    Red,
+    Green,
+    Refactor,
+}
+
+/// Test-Driven Development orchestrator
+pub struct TestDriven {
+    phase: TddPhase,
+    cycles: u32,
+}
+
 impl TestDriven {
-    pub fn new() -> Self { Self { phase: TddPhase::Red, cycles: 0 } }
+    pub fn new() -> Self {
+        Self {
+            phase: TddPhase::Red,
+            cycles: 0,
+        }
+    }
+    
     pub fn next_phase(&mut self) {
         self.phase = match self.phase {
             TddPhase::Red => TddPhase::Green,
             TddPhase::Green => TddPhase::Refactor,
-            TddPhase::Refactor => { self.cycles += 1; TddPhase::Red }
+            TddPhase::Refactor => {
+                self.cycles += 1;
+                TddPhase::Red
+            }
         };
     }
-    pub fn phase(&self) -> TddPhase { self.phase }
-    pub fn cycles(&self) -> u32 { self.cycles }
+    
+    pub fn phase(&self) -> TddPhase {
+        self.phase
+    }
+    
+    pub fn cycles(&self) -> u32 {
+        self.cycles
+    }
 }
-impl Default for TestDriven { fn default() -> Self::new() }
-#[cfg(test)] mod tests {
+
+impl Default for TestDriven {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
     use super::*;
-    #[test] fn test_cycle() {
+    
+    #[test]
+    fn test_cycle() {
         let mut tdd = TestDriven::new();
         assert_eq!(tdd.phase(), TddPhase::Red);
-        tdd.next_phase(); assert_eq!(tdd.phase(), TddPhase::Green);
-        tdd.next_phase(); assert_eq!(tdd.phase(), TddPhase::Refactor);
-        tdd.next_phase(); assert_eq!(tdd.phase(), TddPhase::Red);
+        tdd.next_phase();
+        assert_eq!(tdd.phase(), TddPhase::Green);
+        tdd.next_phase();
+        assert_eq!(tdd.phase(), TddPhase::Refactor);
+        tdd.next_phase();
+        assert_eq!(tdd.phase(), TddPhase::Red);
         assert_eq!(tdd.cycles(), 1);
     }
 }

--- a/crates/arch_test/tests/boundary_tests.rs
+++ b/crates/arch_test/tests/boundary_tests.rs
@@ -110,7 +110,7 @@ fn no_cyclic_dependencies() {
         }
 
         visited.insert(path_str.clone());
-        stack.insert(path_str);
+        stack.insert(path_str.clone());
 
         // Check imports
         if let Ok(content) = std::fs::read_to_string(path) {

--- a/crates/arch_test/tests/tdd_tests.rs
+++ b/crates/arch_test/tests/tdd_tests.rs
@@ -40,7 +40,7 @@ fn test_insert_and_get() {
     let mut map = HashMap::new();
     map.insert("key1", "value1");
 
-    assert_eq!(map.get("key1"), Some(&"value1".to_string()));
+    assert_eq!(map.get("key1"), Some(&"value1"));
 }
 
 /// Test: Update existing value
@@ -50,7 +50,7 @@ fn test_update_existing_value() {
     map.insert("key1", "value1");
     map.insert("key1", "value2");
 
-    assert_eq!(map.get("key1"), Some(&"value2".to_string()));
+    assert_eq!(map.get("key1"), Some(&"value2"));
     assert_eq!(map.len(), 1);
 }
 


### PR DESCRIPTION
## Summary

Adds architectural testing infrastructure crate for heliosCLI:

### Features
- **Boundary enforcement tests** - Validates hexagonal/clean architecture boundaries
- **TDD patterns** - Red-Green-Refactor cycle orchestration
- **Property-based testing** - Using proptest for fuzz/invariant testing

### Structure
```
crates/arch_test/
├── Cargo.toml
└── src/
    ├── lib.rs
    ├── boundary.rs
    ├── tdd.rs
    └── proptest_patterns.rs
```

## Testing
- [x] Unit tests
- [ ] Full integration