### PR TITLE
docs(spec): real PRD, FR, and ADR for heliosCLI

### DIFF
--- a/ADR.md
+++ b/ADR.md
@@ -2,38 +2,155 @@
 
 ## ADR-001: Bazel as Primary Build System
 
-**Status:** Accepted
-**Context:** The monorepo contains Rust (codex-rs) and TypeScript (codex-cli) components that need unified builds, caching, and cross-language dependency management.
-**Decision:** Use Bazel with rules_rust and rules_nodejs for hermetic, cacheable builds.
-**Alternatives:** Cargo + pnpm separately (no unified graph), Nix (steeper learning curve).
-**Consequences:** Build files must be kept in sync; contributors need Bazel familiarity.
+**Status**: Accepted
+**Date**: 2026-03-27
 
-## ADR-002: Rust for Execution Core
+**Context**: The monorepo contains Rust (`codex-rs`, `helios-rs`), TypeScript (`codex-cli`, `shell-tool-mcp`), Python (`harness_pyo3`), Mojo, and Zig components. These need unified dependency graphs, hermetic builds, remote caching, and cross-language test execution.
 
-**Status:** Accepted
-**Context:** The execution engine needs low-latency sandboxing, memory safety, and high concurrency for parallel agent sessions.
-**Decision:** Implement core execution, protocol, and sandbox in Rust (codex-rs workspace).
-**Alternatives:** Go (less control over memory), TypeScript (insufficient for sandboxing).
-**Consequences:** Rust workspace with multiple crates; FFI boundary with TypeScript via protocol serialization.
+**Decision**: Use Bazel with `rules_rust`, `aspect_rules_js`, and `rules_python` as the primary build system. Cargo and pnpm serve as secondary entry points for single-language iteration.
 
-## ADR-003: TypeScript CLI Frontend
+**Rationale**:
+- Bazel's hermetic execution and action-level caching reduce CI wall time on large Rust monorepos.
+- Cross-language targets (generating TypeScript types from Rust schemas) require a unified build graph.
+- Remote execution via `rbe.bzl` enables horizontal scale for CI.
+- `rules_rust` provides first-class Bazel-native Rust support without requiring a custom build bridge.
 
-**Status:** Accepted
-**Context:** The user-facing CLI needs rapid iteration, rich terminal UI, and npm ecosystem access for agent SDKs.
-**Decision:** codex-cli in TypeScript, managed via pnpm workspace.
-**Consequences:** Two language runtimes in CI; protocol types generated from Rust schemas.
+**Alternatives Considered**:
+- Cargo + pnpm separately: no unified dependency graph; cross-language integration requires ad-hoc scripts.
+- Nix: hermetic but steep learning curve and fragile ecosystem integration for Rust nightly.
 
-## ADR-004: Harness Crate Architecture
+**Consequences**:
+- `BUILD.bazel` files must be maintained alongside `Cargo.toml` and `package.json`.
+- Contributors need Bazel familiarity. `justfile` provides shortcut commands.
+- `build.rs` scripts that require network access must be replaced with Bazel `build_script` rules or vendored.
 
-**Status:** Accepted
-**Context:** The benchmark/harness system has multiple concerns: caching, checkpointing, discovery, orchestration, scaling, schema validation.
-**Decision:** Decompose into fine-grained Rust crates under `crates/` (harness_cache, harness_runner, harness_scaling, etc.).
-**Alternatives:** Single monolithic harness crate.
-**Consequences:** Clear module boundaries; some inter-crate dependency management overhead.
+---
 
-## ADR-005: Measured Performance Over Language Novelty
+## ADR-002: Rust for Execution Core and Protocol Layer
 
-**Status:** Accepted
-**Context:** Mojo, Zig, and inline assembly were explored for hot-path optimization.
-**Decision:** Prioritize profiling-driven optimization in Rust. Use Zig/Mojo only when benchmarks show a measurable win that Rust cannot achieve. Inline assembly only after exhausting compiler intrinsics.
-**Consequences:** Mojo and Zig remain optional satellite components, not core runtime.
+**Status**: Accepted
+**Date**: 2026-03-27
+
+**Context**: The execution engine needs OS-level sandbox APIs (Landlock, Seatbelt, Windows job objects), low-latency async I/O for concurrent agent sessions, memory safety for security-critical sandbox enforcement, and the ability to generate typed schemas for TypeScript consumers.
+
+**Decision**: Implement all execution, sandboxing, protocol, MCP server, TUI, and authentication logic in Rust, organized as a multi-crate workspace under `codex-rs/` and `helios-rs/`.
+
+**Rationale**:
+- Rust provides memory-safe FFI to OS sandbox APIs without GC pause risk on latency-sensitive execution paths.
+- `tokio` async runtime handles hundreds of concurrent agent sessions with minimal overhead.
+- `serde` + JSON schema generation enables typed protocol contracts shared with TypeScript via code generation.
+- `clap` + `clap_complete` provides an ergonomic CLI with shell completion support.
+
+**Alternatives Considered**:
+- Go: GC pauses are unacceptable for sandbox enforcement; weaker OS sandbox API integration.
+- TypeScript: insufficient access to OS-level APIs for Landlock/Seatbelt; no viable sandboxing path.
+
+**Consequences**:
+- Rust crate count is large (50+ crates). Crate granularity is managed via ADR-004.
+- TypeScript types are derived from Rust schemas via `helios generate-ts`; the generation step must run before TypeScript builds.
+
+---
+
+## ADR-003: TypeScript CLI Frontend and MCP Package
+
+**Status**: Accepted
+**Date**: 2026-03-27
+
+**Context**: The interactive CLI and `shell-tool-mcp` package benefit from the npm ecosystem for terminal UI libraries, provider SDKs (OpenAI, Anthropic), and rapid iteration.
+
+**Decision**: Maintain `codex-cli` as a TypeScript CLI managed via pnpm workspace. The `shell-tool-mcp` TypeScript package exposes the shell execution MCP tool as an npm-publishable package.
+
+**Rationale**:
+- npm ecosystem provides ready-made SDKs for all major AI providers.
+- TypeScript enforces protocol contracts generated from Rust schemas.
+- `shell-tool-mcp` as an npm package is consumable by MCP clients without requiring a Rust build environment.
+
+**Consequences**:
+- Two language runtimes in CI. TypeScript tests run via vitest; linting via biome.
+- Protocol type definitions must stay in sync with Rust schemas; `helios generate-ts` is the synchronization mechanism.
+- Node version is pinned in `codex-rs/node-version.txt`; pnpm lockfile is committed.
+
+---
+
+## ADR-004: Fine-Grained Harness Crate Architecture
+
+**Status**: Accepted
+**Date**: 2026-03-27
+
+**Context**: The harness system has distinct concerns: caching, checkpointing, discovery, elicitation, interfaces, normalization, orchestration, queue management, rollback, running, scaling, schema validation, task specs, and teammate collaboration. A single harness crate would have high internal coupling.
+
+**Decision**: Decompose the harness into ~15 fine-grained crates under `crates/harness_*`, each with a single responsibility. `harness_orchestrator` is the integration point that composes the others.
+
+**Rationale**:
+- Fine-grained crates enforce explicit dependency relationships; circular dependencies fail at compile time.
+- Each crate is testable in isolation with minimal mocking surface.
+- New scaling strategies or caching backends can be swapped by replacing a single crate.
+- Mojo (`harness_mojo`) and Zig (`harness_zig`) satellite crates remain isolated from the Rust hot path.
+
+**Alternatives Considered**:
+- Single monolithic harness crate: simpler dependency management but degrades into a ball of mud under active development.
+
+**Consequences**:
+- Inter-crate dependency management requires Cargo.toml edits for each new harness concern.
+- `harness_interfaces` crate provides shared trait definitions to prevent circular dependencies.
+
+---
+
+## ADR-005: Profiling-Driven Optimization; Mojo/Zig as Satellites
+
+**Status**: Accepted
+**Date**: 2026-03-27
+
+**Context**: Mojo and Zig were explored as alternatives for performance-critical harness paths. Inline assembly was considered for hot-path optimization.
+
+**Decision**: Default to Rust with profiling-driven optimization. Adopt Mojo or Zig only when profiling demonstrates a measurable improvement that Rust cannot achieve. Inline assembly is last resort after exhausting compiler intrinsics.
+
+**Rationale**:
+- Premature optimization in non-Rust languages adds build complexity before there is evidence of a bottleneck.
+- `perf-results/` tracks benchmark history to provide objective evidence for any future language adoption.
+- Mojo and Zig toolchains are less mature; introducing them as build dependencies risks build system instability.
+
+**Consequences**:
+- `harness_mojo` and `harness_zig` remain satellite experiments and are not in the critical path.
+- Performance regressions are caught by the `heliosBench` benchmark suite run in CI.
+
+---
+
+## ADR-006: Platform-Native Sandbox per OS
+
+**Status**: Accepted
+**Date**: 2026-03-27
+
+**Context**: Available sandbox mechanisms differ across macOS (Seatbelt/sandbox-exec), Linux (Landlock, seccomp, namespaces), and Windows (job objects, restricted tokens). A unified abstraction would result in the lowest common denominator.
+
+**Decision**: Implement a separate sandbox module per platform (`helios-linux-sandbox`, `helios-windows-sandbox-rs`, `SeatbeltCommand`). The `helios sandbox <platform>` subcommand dispatches to the platform-appropriate implementation. A common `helios-execpolicy` crate defines the policy abstraction shared across platforms.
+
+**Rationale**:
+- Platform-specific implementations can use each OS's strongest available mechanism.
+- The `execpolicy` abstraction layer allows policy definitions (allow/deny lists, timeouts) to be expressed once and enforced natively.
+- `helios sandbox linux` falls back to `execpolicy-legacy` on kernels without full Landlock support.
+
+**Consequences**:
+- Platform-specific crates must be conditionally compiled (`#[cfg(target_os = "macos")]`).
+- CI must test on all three platforms; the build matrix from `policy-gate` manages platform-aware testing.
+
+---
+
+## ADR-007: App-Server for Long-Running Agent Sessions
+
+**Status**: Accepted
+**Date**: 2026-03-27
+
+**Context**: AI coding sessions may run for minutes to hours. CLI processes are not robust to terminal disconnection. A background service model allows sessions to continue independently of the terminal.
+
+**Decision**: Run a background `app-server` process that manages agent session state. The `helios` CLI connects to it via Unix domain socket (or named pipe on Windows). `helios stdio-to-uds` provides a bridge for tools that communicate via stdio.
+
+**Rationale**:
+- Session state (conversation history, file edits, tool outputs) is durable across terminal reconnects.
+- Multiple CLI processes can observe the same session.
+- The typed `helios-app-server-protocol` is versionable; breaking changes require a server restart, not a full session restart.
+
+**Consequences**:
+- `helios app-server start/stop/status` lifecycle commands must be documented.
+- The server PID must be tracked in `$HELIOS_HOME` to prevent duplicate instances.
+- `helios debug app-server send-message-v2` provides a development escape hatch for protocol testing.

--- a/FUNCTIONAL_REQUIREMENTS.md
+++ b/FUNCTIONAL_REQUIREMENTS.md
@@ -2,68 +2,226 @@
 
 ## FR-CLI: Command-Line Interface
 
-### FR-CLI-001: Agent Dispatch
+### FR-CLI-001: Multi-Backend Agent Dispatch
+The `helios` binary SHALL dispatch to any registered AI backend via `--model` and `--provider` flags, with alias expansion for `oss-provider`/`local-provider` -> `oss_provider`.
+Traces to: E1.1
 
-The CLI SHALL dispatch commands to any registered agent backend (Codex, Claude, Gemini, Cursor, Copilot) via `helios run --agent <name>`.
-**Traces to:** E1.1
+### FR-CLI-002: Default Interactive TUI Launch
+When stdin is a TTY and no subcommand is given, the binary SHALL launch the `helios-tui` interactive session.
+Traces to: E1.2
 
-### FR-CLI-002: Interactive Mode
+### FR-CLI-003: Batch Non-Interactive Mode
+When stdin is not a TTY, the binary SHALL process piped input without interactive prompts and exit with code 0 on success, non-zero on error.
+Traces to: E1.3
 
-The CLI SHALL provide an interactive REPL via `helios chat` with streaming output from the selected agent.
-**Traces to:** E1.2
+### FR-CLI-004: Session Resume
+`helios resume <session-id>` SHALL restore a prior session state from `$HELIOS_HOME/sessions/`.
+Traces to: E1.2
 
-### FR-CLI-003: Batch Mode
+### FR-CLI-005: Session Fork
+`helios fork` SHALL create a new session branched from an existing session, inheriting conversation history up to the fork point.
+Traces to: E1.2
 
-The CLI SHALL accept piped stdin input and return structured output with appropriate exit codes.
-**Traces to:** E1.2
+### FR-CLI-006: Apply Patch
+`helios apply <patch-file>` SHALL apply a unified diff to the working tree via the `ApplyCommand` in `helios-chatgpt`.
+Traces to: E1.4
 
-## FR-EXC: Execution Core
+### FR-CLI-007: Shell Completion
+`helios completion <shell>` SHALL emit shell completion scripts for Bash, Zsh, Fish, and PowerShell via `clap_complete`.
+Traces to: E1.1
 
-### FR-EXC-001: Filesystem Sandbox
+---
 
-The execution engine SHALL restrict AI-generated code to designated directories; writes outside the sandbox SHALL fail with an explicit error.
-**Traces to:** E2.1
+## FR-SBX: Sandboxed Execution
 
-### FR-EXC-002: Network Policy
+### FR-SBX-001: macOS Seatbelt Sandbox
+`helios sandbox macos` SHALL configure and launch a Seatbelt (`sandbox-exec`) profile restricting writes to the designated workspace directory and enforcing network policy.
+Traces to: E2.1
 
-The execution engine SHALL support configurable network access policies (allow/deny per domain pattern).
-**Traces to:** E2.1
+### FR-SBX-002: Linux Landlock Sandbox
+`helios sandbox linux` SHALL configure and apply a Landlock ruleset restricting filesystem access and enforcing network policy via `helios-execpolicy`.
+Traces to: E2.1
 
-### FR-EXC-003: Execution Timeout
+### FR-SBX-003: Windows Sandbox
+`helios sandbox windows` SHALL configure Windows job object restrictions for filesystem and process isolation.
+Traces to: E2.1
 
-The execution engine SHALL enforce configurable timeouts and terminate runaway processes.
-**Traces to:** E2.1
+### FR-SBX-004: Write-Outside-Workspace Denial
+All sandbox implementations SHALL deny write operations to paths outside the designated workspace directory and emit an explicit error message naming the denied path.
+Traces to: E2.1
 
-### FR-EXC-004: Protocol Serialization
+### FR-SBX-005: Configurable Network Policy
+All sandbox implementations SHALL support a configurable network access policy with allow/deny rules per domain pattern, read from the helios config file.
+Traces to: E2.1
 
-The protocol layer SHALL use typed Rust structs with serde for serialization and generate TypeScript type definitions.
-**Traces to:** E2.2
+### FR-SBX-006: Execution Timeout
+All sandbox implementations SHALL enforce a configurable execution timeout; processes SHALL be terminated when the timeout elapses and the error SHALL include the timeout duration and process identity.
+Traces to: E2.1
+
+### FR-SBX-007: Execution Policy Check
+`helios execpolicy check` SHALL evaluate the current execution policy configuration and report each policy assertion as pass/fail.
+Traces to: E2.1
+
+---
+
+## FR-SRV: App Server and Protocol
+
+### FR-SRV-001: App Server Lifecycle
+`helios app-server start` SHALL launch the background app-server process; `helios app-server stop` SHALL terminate it; `helios app-server status` SHALL report health.
+Traces to: E2.2
+
+### FR-SRV-002: Typed Protocol Messages
+All IPC messages between CLI and app-server SHALL use typed structs defined in `helios-app-server-protocol` with serde JSON serialization.
+Traces to: E2.2
+
+### FR-SRV-003: stdio-to-UDS Bridge
+`helios stdio-to-uds <socket-path>` SHALL bridge the process's stdin/stdout to the specified Unix domain socket.
+Traces to: E2.2
+
+### FR-SRV-004: MCP Server Integration
+`helios mcp` SHALL start the embedded MCP server exposing registered tools over the MCP protocol to external AI clients.
+Traces to: E2.3
+
+### FR-SRV-005: Shell Tool MCP Package
+The `shell-tool-mcp` npm package SHALL expose a shell-execution MCP tool with a compliant JSON schema, tests, and sandbox policy enforcement.
+Traces to: E5.3
+
+---
+
+## FR-AUTH: Authentication
+
+### FR-AUTH-001: API Key Login
+`helios login --api-key` SHALL accept an API key from stdin and store it via `helios-keyring-store` in the system keyring.
+Traces to: E2.5
+
+### FR-AUTH-002: Device-Code OAuth
+`helios login` without flags SHALL initiate a device-code OAuth flow with the configured provider.
+Traces to: E2.5
+
+### FR-AUTH-003: ChatGPT Browser Login
+`helios login chatgpt` SHALL initiate a browser-based ChatGPT authentication flow via `helios-chatgpt`.
+Traces to: E2.5
+
+### FR-AUTH-004: Login Status
+`helios login status` SHALL display currently authenticated providers, token types, and expiry information.
+Traces to: E2.5
+
+### FR-AUTH-005: Logout
+`helios logout` SHALL remove credentials for all providers from the system keyring.
+Traces to: E2.5
+
+---
+
+## FR-CFG: Configuration
+
+### FR-CFG-001: Config Home Resolution
+The binary SHALL resolve `$HELIOS_HOME` from the environment; if unset, default to `~/.helios`. Config files SHALL be read from this directory.
+Traces to: E2.6
+
+### FR-CFG-002: Config Edit
+`helios config edit` SHALL open the config file in `$EDITOR` or a fallback editor.
+Traces to: E2.6
+
+### FR-CFG-003: Config Override
+`helios config set <key> <value>` SHALL apply a single config key-value pair by writing through `ConfigEditsBuilder`.
+Traces to: E2.6
+
+### FR-CFG-004: TypeScript Schema Generation
+`helios generate-ts` SHALL emit TypeScript type definitions derived from the Rust config JSON schema to a configured output path.
+Traces to: E2.6
+
+### FR-CFG-005: Feature Flags
+The config SHALL support feature-flag entries gated by `Stage` (alpha/beta/stable). Features not at or above the configured stage SHALL be disabled at runtime.
+Traces to: E2.6
+
+---
+
+## FR-RESP: Responses API Proxy
+
+### FR-RESP-001: Local Proxy Endpoint
+`helios-responses-api-proxy` SHALL expose a local HTTP server endpoint compatible with the OpenAI Responses API format.
+Traces to: E2.4
+
+### FR-RESP-002: Streaming SSE
+The proxy SHALL forward streamed responses from the backend as Server-Sent Events on the local endpoint.
+Traces to: E2.4
+
+---
 
 ## FR-HAR: Harness System
 
-### FR-HAR-001: Benchmark Suite Definition
+### FR-HAR-001: Suite Manifest Loading
+`harness_spec` SHALL load suite manifests from TOML or YAML files; `harness_discoverer` SHALL recursively scan configured directories.
+Traces to: E3.1
 
-The harness SHALL load benchmark suites from TOML/YAML manifest files specifying tasks, agents, and success criteria.
-**Traces to:** E3.1
+### FR-HAR-002: Task Execution
+`harness_runner` SHALL execute each harness task by sending the task prompt to the configured agent and capturing the raw response.
+Traces to: E3.1
 
-### FR-HAR-002: Results Output
+### FR-HAR-003: Concurrency Control
+`harness_queue` SHALL maintain a FIFO task queue; `harness_orchestrator` SHALL dispatch tasks to a configurable number of concurrent `harness_runner` instances.
+Traces to: E3.2
 
-The harness SHALL produce structured JSON results with timing, token usage, and correctness metrics per task.
-**Traces to:** E3.1
+### FR-HAR-004: Dynamic Scaling
+`harness_scaling` SHALL adjust the pool of active runners based on queue depth and configurable scaling rules.
+Traces to: E3.2
 
-### FR-HAR-003: Concurrent Execution
+### FR-HAR-005: Output Verification
+`harness_verify` SHALL evaluate each task output against success criteria defined in the suite manifest and assign a correctness verdict (pass/fail/partial).
+Traces to: E3.3
 
-The harness SHALL support configurable concurrency for running N parallel agent sessions with queue-based task distribution.
-**Traces to:** E3.2
+### FR-HAR-006: Output Normalization
+`harness_normalizer` SHALL normalize raw agent outputs to a canonical form before verification and comparison.
+Traces to: E3.3
 
-## FR-BLD: Build and CI
+### FR-HAR-007: Checkpoint and Rollback
+`harness_checkpoint` SHALL persist harness state after each completed task. `harness_rollback` SHALL restore from the most recent checkpoint on abort or crash.
+Traces to: E3.3
 
-### FR-BLD-001: Bazel Build
+### FR-HAR-008: Response Cache
+`harness_cache` SHALL cache LLM responses keyed by (model, prompt hash); cached responses SHALL be replayed on re-run when the cache hit matches.
+Traces to: E3.3
 
-All Rust and TypeScript targets SHALL build successfully via `bazel build //...`.
-**Traces to:** E4.1
+### FR-HAR-009: Results JSON Output
+The harness SHALL produce a structured JSON results file with per-task fields: agent, model, latency_ms, prompt_tokens, completion_tokens, correctness_verdict, raw_output. Aggregate fields: pass_rate, p50/p90/p99 latency, estimated_cost.
+Traces to: E3.4
 
-### FR-BLD-002: CI Checks
+### FR-HAR-010: Python Bindings
+`harness_pyo3` SHALL expose `HarnessRunner` and `HarnessOrchestrator` classes to Python via pyo3, installable as a native Python extension.
+Traces to: E3.5
 
-PRs SHALL pass: Rust clippy + fmt + tests, TypeScript lint + tests, Bazel build + test, and policy gate validation.
-**Traces to:** E4.2
+---
+
+## FR-CT: Cloud Tasks
+
+### FR-CT-001: Task Submission
+`helios cloud-tasks submit` SHALL serialize a task request via `helios-cloud-tasks` and dispatch it to the configured cloud endpoint.
+Traces to: E4.1
+
+### FR-CT-002: Task Status Polling
+`helios cloud-tasks status <task-id>` SHALL poll the cloud endpoint and display the current task state until completion or timeout.
+Traces to: E4.1
+
+### FR-CT-003: HTTP Transport with Retry
+`helios-cloud-tasks-client` SHALL implement exponential-backoff retry on 5xx responses and network errors, with configurable max retries.
+Traces to: E4.1
+
+---
+
+## FR-BUILD: Build and CI
+
+### FR-BUILD-001: Hermetic Bazel Build
+`bazel build //...` SHALL produce all Rust and TypeScript artifacts without network access after the initial dependency fetch.
+Traces to: E5.1
+
+### FR-BUILD-002: Full Test Suite
+`bazel test //...` SHALL run all test targets. `cargo test --workspace` and `pnpm --filter codex-cli test` SHALL be equivalent secondary entry points.
+Traces to: E5.2
+
+### FR-BUILD-003: Rust Quality Gates
+All Rust code SHALL pass `cargo clippy --workspace -- -D warnings` and `cargo fmt --check` with zero errors.
+Traces to: E5.2
+
+### FR-BUILD-004: Policy Gate Integration
+All PRs SHALL invoke `KooshaPari/phenotypeActions/actions/policy-gate@v0` to enforce namespace ownership, merge-commit, and layered-fix policies.
+Traces to: E5.2

--- a/PRD.md
+++ b/PRD.md
@@ -2,93 +2,216 @@
 
 ## Product Vision
 
-heliosCLI is a multi-runtime AI coding CLI that unifies Codex, Claude, Gemini, Cursor, and Copilot agents behind a single command-line interface. Built as a Bazel monorepo with a Rust execution core (`codex-rs`) and TypeScript CLI frontend (`codex-cli`), it provides sandboxed code execution, multi-agent orchestration, and a harness system for benchmarking and scaling AI workloads.
+heliosCLI is a multi-runtime AI coding assistant CLI that unifies multiple AI coding backends (Codex/OpenAI, Claude, Gemini, ChatGPT, local OSS providers) behind a single `helios` command. It is structured as a Bazel monorepo with three primary layers: a Rust core (`codex-rs`) providing sandboxed execution, protocol handling, MCP server hosting, and TUI; a Helios-specific Rust CLI layer (`helios-rs/cli`) that extends the core with login, app-server management, cloud tasks, and platform-specific sandbox controls; and a TypeScript CLI (`codex-cli`) as the user-facing command interface. A harness subsystem (`crates/harness_*`) provides benchmarking, scaling, and multi-agent orchestration for AI workload evaluation.
 
-## E1: Multi-Agent CLI
+---
 
-### E1.1: Unified Agent Interface
+## E1: Multi-Runtime AI CLI
 
-As a developer, I can invoke any supported AI agent (Codex, Claude, Gemini, Cursor, Copilot) through a single `helios` command.
+### E1.1: Unified Agent Dispatch
 
-**Acceptance Criteria:**
+As a developer, I can invoke any supported AI backend through a single `helios` command with a consistent flag interface.
 
-- `helios run --agent <name>` dispatches to the correct backend
-- Agent list is discoverable via `helios agents list`
-- Common flags (model, temperature, max-tokens) work across all agents
+**Acceptance Criteria**:
+- Default invocation (no subcommand) forwards options to the interactive TUI.
+- `--model`, `--provider` flags select the backend; shorthand aliases `oss-provider` and `local-provider` map to `oss_provider`.
+- Backend selection supports: OpenAI/Codex, Claude (Anthropic), Gemini, ChatGPT (via `helios-chatgpt`), local/OSS providers, LM Studio, Ollama.
+- `helios completion <shell>` generates shell completions for Bash, Zsh, Fish, PowerShell.
 
-### E1.2: Interactive and Batch Modes
+### E1.2: Interactive TUI Mode
 
-As a developer, I can use helios interactively (REPL) or in batch mode (piped input, scripts).
+As a developer, I want an interactive terminal UI for ongoing coding conversations with an AI agent.
 
-**Acceptance Criteria:**
+**Acceptance Criteria**:
+- Default invocation (TTY detected, no subcommand) launches `helios-tui` with streaming output.
+- TUI supports multi-turn conversation, file context injection, and tool-use display.
+- `ExitReason` and `AppExitInfo` are surfaced to the parent process for scripting.
+- `helios resume <session-id>` resumes a prior session.
+- `helios fork` creates a new session branched from an existing one.
 
-- `helios chat` opens interactive session with selected agent
-- `echo "fix bug" | helios run` processes batch input
-- Exit codes reflect success/failure for CI integration
+### E1.3: Batch / Non-Interactive Mode
+
+As a CI script, I want to pipe prompts to helios and receive structured output with correct exit codes.
+
+**Acceptance Criteria**:
+- When stdin is not a TTY, `helios` operates in batch mode without interactive prompts.
+- Exit code 0 on success; non-zero on agent error or sandbox violation.
+- Output includes structured JSON when `--json` flag is set.
+
+### E1.4: Apply Patch Command
+
+As a developer, I can apply AI-generated patches to the working directory via `helios apply`.
+
+**Acceptance Criteria**:
+- `helios apply <patch-file>` applies a unified diff to the working tree.
+- The `ApplyCommand` delegates to `helios-chatgpt`'s apply logic.
+- Dry-run mode (`--dry-run`) reports changes without applying them.
+
+---
 
 ## E2: Rust Execution Core (codex-rs)
 
-### E2.1: Sandboxed Code Execution
+### E2.1: Platform-Specific Sandboxed Execution
 
-As a developer, I can execute AI-generated code in a sandboxed environment with filesystem and network restrictions.
+As a developer, AI-generated code executes in a sandboxed environment appropriate for the host OS.
 
-**Acceptance Criteria:**
+**Acceptance Criteria**:
+- macOS: uses Seatbelt (`sandbox-exec`) via `helios sandbox macos`.
+- Linux: uses Landlock via `helios sandbox linux`.
+- Windows: uses Windows job objects and restricted tokens via `helios sandbox windows`.
+- All sandbox implementations enforce: write-outside-workspace denied; configurable network access; execution timeout.
+- `helios execpolicy check` evaluates the current execution policy configuration.
 
-- Sandbox prevents writes outside designated directories
-- Network access is configurable (allow/deny per domain)
-- Execution timeout with configurable limits
+### E2.2: Protocol and App-Server
 
-### E2.2: Protocol Layer
+As a developer, a local app-server provides a stable IPC channel between the CLI and background agent processes.
 
-As a developer, the CLI communicates with agents via a typed protocol with structured request/response messages.
+**Acceptance Criteria**:
+- `helios app-server start` launches the background app-server process.
+- `helios app-server status` reports health of the running server.
+- Protocol messages are typed via `helios-app-server-protocol` crate; test client available via `helios-app-server-test-client`.
+- `helios debug app-server send-message-v2` provides a debug hook for protocol testing.
+- `helios stdio-to-uds` bridges stdio to a Unix domain socket for process connection.
 
-**Acceptance Criteria:**
+### E2.3: MCP Server
 
-- Protocol defined as Rust types with serde serialization
-- Schema artifacts generated for TypeScript consumers
-- Backward-compatible versioning for protocol changes
+As an agent tool author, I can expose tools to AI backends via the Model Context Protocol server built into helios.
+
+**Acceptance Criteria**:
+- `helios mcp` subcommand manages the embedded MCP server.
+- MCP server exposes registered tools over the MCP wire protocol.
+- Tool registration is driven by the `codex-rs/skills` and `codex-rs/mcp-server` crates.
+- `shell-tool-mcp` TypeScript package provides a shell-execution MCP tool consumable by external clients.
+
+### E2.4: Responses API Proxy
+
+As a developer, I can route agent requests through a local responses-API-compatible proxy for observability and provider switching.
+
+**Acceptance Criteria**:
+- `helios-responses-api-proxy` crate exposes a local HTTP endpoint compatible with the OpenAI Responses API.
+- Requests are forwarded to the configured backend provider.
+- Proxy supports streaming SSE responses.
+
+### E2.5: Login and Authentication
+
+As a developer, I authenticate to AI providers via `helios login`.
+
+**Acceptance Criteria**:
+- `helios login` supports: API key from stdin (`--api-key`), device-code OAuth flow, ChatGPT browser-based login.
+- `helios login status` shows currently authenticated providers and token validity.
+- `helios logout` removes stored credentials.
+- Credentials are stored via `helios-keyring-store` (system keyring integration).
+
+### E2.6: Configuration Management
+
+As a developer, I manage helios configuration via `helios config`.
+
+**Acceptance Criteria**:
+- Config is read from `$HELIOS_HOME` (default: `~/.helios`).
+- `helios config edit` opens config in the user's editor.
+- `helios config set <key> <value>` applies a single config override.
+- `helios generate-ts` generates TypeScript type definitions from the config JSON schema.
+- Feature flags are managed via `helios-core/features` with `Stage` gating.
+
+---
 
 ## E3: Harness System
 
-### E3.1: Benchmark Harness
+### E3.1: Benchmark Suite Definition and Loading
 
-As a developer, I can benchmark AI agent performance across standardized coding tasks.
+As a developer, I can define benchmark suites as structured manifests and run them against any configured AI backend.
 
-**Acceptance Criteria:**
+**Acceptance Criteria**:
+- Harness suite manifests are loaded by `harness_spec` and `harness_schema` crates.
+- Each task in a suite defines: prompt, expected outputs, success criteria, timeout.
+- `harness_discoverer` scans configured directories for suite manifests.
+- `harness_elicitation` handles prompting the AI backend and capturing raw responses.
 
-- Define benchmark suites as TOML/YAML manifests
-- Run benchmarks with `helios bench run <suite>`
-- Results output as structured JSON with timing, token usage, and correctness metrics
+### E3.2: Multi-Agent Orchestration and Scaling
 
-### E3.2: Scaling and Orchestration
+As an operator, I can run harness workloads across N concurrent agent sessions with queue-based task distribution.
 
-As an operator, I can scale harness workloads across multiple concurrent agent sessions.
+**Acceptance Criteria**:
+- `harness_orchestrator` manages the execution lifecycle: queue, dispatch, collect.
+- `harness_queue` provides FIFO task queuing with concurrency control.
+- `harness_scaling` dynamically adjusts the number of active agent sessions based on load.
+- `harness_runner` executes individual tasks and captures results.
+- `harness_teammates` supports multi-agent collaboration on a single task.
 
-**Acceptance Criteria:**
+### E3.3: Results, Verification, and Rollback
 
-- Configurable concurrency (N parallel agent sessions)
-- Queue-based task distribution across sessions
-- Aggregated results with statistical summaries
+As a developer, harness results are verified, normalized, and stored with rollback capability.
 
-## E4: Build and CI
+**Acceptance Criteria**:
+- `harness_verify` validates task outputs against defined success criteria.
+- `harness_normalizer` normalizes outputs for consistent comparison across agents.
+- `harness_checkpoint` snapshots harness state for resumability after failure.
+- `harness_rollback` restores prior state when a harness run is aborted.
+- `harness_cache` caches LLM responses for deterministic replay and cost reduction.
 
-### E4.1: Bazel Monorepo Build
+### E3.4: Results Output and Reporting
 
-As a contributor, I can build and test all components (Rust, TypeScript) via Bazel.
+As a developer, harness results are exported as structured JSON with timing, token usage, and correctness metrics.
 
-**Acceptance Criteria:**
+**Acceptance Criteria**:
+- Results include per-task fields: agent, model, latency, token count, correctness verdict, raw output.
+- Aggregated summary includes pass rate, P50/P90/P99 latency, cost estimate.
+- `thegent-benchmark` crate integrates with the `thegent` orchestration layer for cross-repo benchmarking.
 
-- `bazel build //...` succeeds for all targets
-- `bazel test //...` runs all test suites
-- Incremental builds cache correctly
+### E3.5: Python and Native Bindings
 
-### E4.2: CI Pipeline
+As a data scientist, I can run harness workloads from Python via pyo3 bindings.
 
-As a contributor, PRs are validated by automated CI checks.
+**Acceptance Criteria**:
+- `harness_pyo3` exposes the harness runner and orchestrator to Python.
+- `harness-native` crate (the Cargo workspace member) provides native extension build artifacts.
+- Mojo (`harness_mojo`) and Zig (`harness_zig`) satellite extensions are available for high-performance task execution.
 
-**Acceptance Criteria:**
+---
 
-- Rust: clippy, fmt, cargo test
-- TypeScript: biome lint, vitest
-- Bazel: build and test all targets
-- Policy gate enforces PR conventions
+## E4: Cloud Tasks
+
+### E4.1: Remote Task Dispatch
+
+As an operator, I can dispatch long-running AI tasks to a cloud backend and poll for results.
+
+**Acceptance Criteria**:
+- `helios cloud-tasks submit <task>` dispatches a task to the cloud backend.
+- `helios cloud-tasks status <task-id>` polls task completion.
+- `helios-cloud-tasks` crate provides typed request/response structs with serde serialization.
+- `helios-cloud-tasks-client` handles HTTP transport and retry logic.
+
+---
+
+## E5: Build and CI
+
+### E5.1: Bazel Monorepo Build
+
+As a contributor, all components build via `bazel build //...` with hermetic, cached builds.
+
+**Acceptance Criteria**:
+- `bazel build //...` succeeds for all Rust and TypeScript targets.
+- `bazel test //...` runs all test suites.
+- Incremental builds use action cache; clean builds are hermetic.
+- `rules_rust` manages Rust toolchain; `aspect_rules_js` manages Node toolchain.
+
+### E5.2: CI Pipeline
+
+As a contributor, PRs trigger automated CI checks across Rust, TypeScript, and Bazel layers.
+
+**Acceptance Criteria**:
+- Rust: `clippy --workspace -D warnings`, `fmt --check`, `cargo test --workspace`.
+- TypeScript: biome lint, vitest test suite.
+- Bazel: build and test all targets.
+- Policy gate (`KooshaPari/phenotypeActions/actions/policy-gate`) enforces PR conventions.
+- Stage gates evaluated on merge to `main`.
+
+### E5.3: shell-tool-mcp TypeScript Package
+
+As an agent tool consumer, I can install `shell-tool-mcp` as an MCP server that executes shell commands in a sandboxed environment.
+
+**Acceptance Criteria**:
+- Package is publishable from `shell-tool-mcp/`.
+- Provides MCP-compliant tool schema for shell execution.
+- Integrates with helios sandbox policies for network and filesystem restrictions.
+- Tests in `shell-tool-mcp/tests/` cover tool invocation and error paths.


### PR DESCRIPTION
## Summary

- Replaced stub PRD.md, FUNCTIONAL_REQUIREMENTS.md, and ADR.md with real specification documents derived from analysis of actual source code
- PRD covers 5 epics: multi-runtime AI CLI (TUI, batch, apply, fork/resume), Rust execution core (platform sandboxes, app-server, MCP, auth, config), harness system (15-crate decomposition), cloud tasks, and build/CI
- FUNCTIONAL_REQUIREMENTS.md has 34 requirements across FR-CLI, FR-SBX, FR-SRV, FR-AUTH, FR-CFG, FR-RESP, FR-HAR, FR-CT, FR-BUILD categories with traces to PRD epics
- ADR.md documents 7 decisions: Bazel monorepo, Rust core rationale, TypeScript CLI, fine-grained harness crates, profiling-driven perf (Mojo/Zig as satellites), platform-native sandboxes, and app-server architecture

## Test plan

- [ ] Verify PRD.md renders cleanly in GitHub markdown view
- [ ] Verify FR IDs and trace labels match PRD epic numbering
- [ ] Spot-check ADR-006 (platform sandbox) against sandbox module locations in codex-rs/

🤖 Generated with [Claude Code](https://claude.com/claude-code)