### PR TITLE
chore(specs): migrate kitty-specs to AgilePlus format, archive BMAD refs

### DIFF
--- a/.agileplus/specs/001-codex-tui-renderer-optimization/meta.json
+++ b/.agileplus/specs/001-codex-tui-renderer-optimization/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "001-codex-tui-renderer-optimization",
+  "title": "Codex TUI Renderer Optimization",
+  "status": "active",
+  "created": "2026-02-28"
+}

--- a/.agileplus/specs/001-codex-tui-renderer-optimization/spec.md
+++ b/.agileplus/specs/001-codex-tui-renderer-optimization/spec.md
@@ -1,0 +1,74 @@
+# Feature Specification: Codex TUI Renderer Optimization
+
+**Feature Branch**: `001-codex-tui-renderer-optimization`  
+**Created**: 2026-02-28  
+**Status**: Draft  
+**Mission**: research
+
+## Summary
+Produce a research-grade architecture walkthrough of the current Codex TUI renderer and its backend event/runtime architecture, then define a layered optimization roadmap informed by octorus and Rust TUI performance practices.
+
+## Problem Statement
+Current renderer and backend behavior are distributed across multiple modules, making it hard to reason about frame scheduling, event flow, and optimization leverage points. This blocks reliable prioritization for high-impact performance work.
+
+## Goals
+- Deliver an architecture walkthrough for current TUI rendering and backend event flow.
+- Provide ASCII diagrams that can be used directly in planning and PR discussions.
+- Produce optimization research grounded in concrete evidence and source tracking.
+- Define a layered PR strategy that can be executed incrementally with clear outcomes.
+
+## Non-Goals
+- Implementing renderer changes in this feature.
+- Executing benchmark harness changes in this feature.
+- Merging any runtime refactor in this feature.
+
+## Actors
+- CLI maintainers prioritizing performance work.
+- Agent implementers executing follow-on layered PRs.
+- Reviewers validating architecture and optimization rationale.
+
+## User Scenarios & Testing
+### Primary Scenario
+A maintainer needs a trusted architecture baseline and optimization sequence before authoring implementation PRs.
+
+### Acceptance Scenarios
+1. Given the feature artifacts, maintainers can trace render lifecycle from input event to frame flush.
+2. Given the backend diagram, maintainers can trace how model events become UI updates.
+3. Given optimization findings, maintainers can identify phased PRs with measurable expected impact.
+4. Given source logs, reviewers can audit every major claim against recorded evidence.
+
+## Functional Requirements
+- **FR-001**: The feature MUST provide a current-state TUI renderer architecture walkthrough.
+- **FR-002**: The feature MUST provide a current-state backend architecture walkthrough relevant to TUI rendering.
+- **FR-003**: The feature MUST include ASCII diagrams for both renderer and backend flows.
+- **FR-004**: The feature MUST capture optimization opportunities prioritized by expected user-visible impact.
+- **FR-005**: The feature MUST include a layered PR strategy with explicit sequencing and dependency intent.
+- **FR-006**: The feature MUST maintain an auditable evidence trail with source register and finding log.
+- **FR-007**: The feature MUST record open questions and risks for follow-on planning.
+
+## Success Criteria
+- 100% of major architecture claims map to at least one source entry in the evidence logs.
+- Maintainers can identify at least 3 independent optimization PR layers without additional discovery.
+- The produced diagrams are sufficient for review discussion without requiring code navigation for basic flow understanding.
+- At least 5 optimization recommendations are ranked with rationale and expected impact class.
+
+## Key Entities
+- **Renderer Path**: Ordered stages from input/event to frame scheduling and terminal flush.
+- **Backend Event Path**: Ordered stages from protocol/model events to UI state updates.
+- **Optimization Candidate**: A measurable improvement hypothesis with impact and risk level.
+- **Layered PR Slice**: A bounded change unit in a dependency-aware sequence.
+- **Evidence Entry**: A traceable source-backed finding record.
+
+## Dependencies
+- Access to current `heliosCLI` codebase paths under `codex-rs/`.
+- Public references for Rust TUI optimization practices.
+
+## Assumptions
+- Target branch for follow-on execution is `main`.
+- This feature remains research-only and does not include code behavior changes.
+- Layered PR execution will be performed in a later implementation phase.
+
+## Risks
+- Architecture drift if code changes significantly before follow-on PRs begin.
+- Overfitting recommendations to one workload profile without benchmark baselines.
+

--- a/.agileplus/specs/001-codex-tui-renderer-optimization/tasks.md
+++ b/.agileplus/specs/001-codex-tui-renderer-optimization/tasks.md
@@ -1,0 +1,3 @@
+# Tasks
+
+_No work packages defined yet._

--- a/.archive/kitty-specs/001-codex-tui-renderer-optimization/checklists/requirements.md
+++ b/.archive/kitty-specs/001-codex-tui-renderer-optimization/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Codex TUI Renderer Optimization
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-28
+**Feature**: /Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/kitty-specs/001-codex-tui-renderer-optimization/spec.md
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass completed in one iteration.
+- `spec-kitty agent feature create-feature` returned an environment/setup error in this repository; feature directory was scaffolded manually to unblock planning artifacts.
+- Items marked incomplete require spec updates before `/spec-kitty.clarify` or `/spec-kitty.plan`

--- a/.archive/kitty-specs/001-codex-tui-renderer-optimization/data-model.md
+++ b/.archive/kitty-specs/001-codex-tui-renderer-optimization/data-model.md
@@ -1,0 +1,54 @@
+# Data Model: Codex TUI Renderer Optimization Research
+
+## Entities
+
+### RendererStage
+- id: string
+- name: string
+- category: enum(input, schedule, compose, draw, flush)
+- owner_module: string
+- measurable_outputs: list[string]
+
+### BackendStage
+- id: string
+- name: string
+- category: enum(entrypoint, thread, model_client, protocol, ui_dispatch)
+- owner_module: string
+- measurable_outputs: list[string]
+
+### EventClass
+- id: string
+- source: string
+- priority: enum(critical, normal, low)
+- burst_profile: enum(low, medium, high)
+- coalescible: boolean
+
+### OptimizationCandidate
+- id: string
+- title: string
+- layer: string
+- expected_impact: enum(low, medium, high)
+- risk_level: enum(low, medium, high)
+- dependencies: list[string]
+- evidence_refs: list[string]
+
+### LayeredPR
+- id: string
+- name: string
+- order_index: integer
+- objective: string
+- success_signal: string
+- depends_on: list[string]
+
+### EvidenceRecord
+- evidence_id: string
+- source_id: string
+- claim: string
+- confidence: enum(low, medium, high)
+
+## Relationships
+- RendererStage emits EventClass.
+- BackendStage emits EventClass.
+- OptimizationCandidate targets one or more RendererStage or BackendStage entries.
+- LayeredPR implements one or more OptimizationCandidate entries.
+- EvidenceRecord supports OptimizationCandidate and LayeredPR rationale.

--- a/.archive/kitty-specs/001-codex-tui-renderer-optimization/meta.json
+++ b/.archive/kitty-specs/001-codex-tui-renderer-optimization/meta.json
@@ -1,0 +1,10 @@
+{
+  "feature_number": "001",
+  "slug": "001-codex-tui-renderer-optimization",
+  "friendly_name": "Codex TUI Renderer Optimization",
+  "mission": "research",
+  "source_description": "https://dev.to/ushironoko/how-octorus-renders-300k-lines-of-diff-at-high-speed-h4p review the following and otehr Rust  TUI optimizatiosn + walk through current codex TUI  renderer levle arhcitecture and give ascii digrams showing it and its backend arch too. In a worktree write in research for how to improve and open a PR requesting an agent open a aleyrerd PR w plans andor optimized research",
+  "created_at": "2026-02-28T09:49:48Z",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/.archive/kitty-specs/001-codex-tui-renderer-optimization/pr-layered-strategy.md
+++ b/.archive/kitty-specs/001-codex-tui-renderer-optimization/pr-layered-strategy.md
@@ -1,0 +1,37 @@
+# Draft PR Description: Layered TUI Optimization Program
+
+## Title
+Layered research-backed plan for Codex TUI renderer and backend optimization
+
+## Summary
+This PR introduces research artifacts and a dependency-aware plan for layered performance work in the Codex TUI stack. It does not change runtime behavior. It establishes architecture baselines, optimization candidates, and auditable evidence for follow-on implementation PRs.
+
+## Why
+- Current performance work lacks a single architecture baseline.
+- Follow-on optimization work needs explicit slicing to reduce risk and improve reviewability.
+- Reviewers need source-backed rationale for each optimization layer.
+
+## Scope
+- Adds `kitty-specs/001-codex-tui-renderer-optimization/spec.md`.
+- Adds checklist validation results.
+- Adds research outputs: architecture walkthrough, ASCII diagrams, evidence log, source register, and data model.
+- Adds proposed layered PR sequence (PR-A through PR-E).
+
+## Requested Follow-Up (Agent)
+Please open a layered implementation PR series based on this research package:
+1. PR-A instrumentation and benchmark baselines.
+2. PR-B render workload reduction.
+3. PR-C event backpressure/coalescing.
+4. PR-D data-structure efficiency changes.
+5. PR-E progressive rendering UX.
+
+Each PR should include clear success signals and should not skip prerequisite layers.
+
+## Risk Management
+- Research-only PR keeps behavior unchanged.
+- Layering allows rollback and isolated validation per concern.
+
+## Reviewer Checklist
+- Confirm architecture diagrams match current code paths.
+- Confirm optimization rationale is evidence-backed.
+- Confirm layer sequence is dependency-safe.

--- a/.archive/kitty-specs/001-codex-tui-renderer-optimization/research.md
+++ b/.archive/kitty-specs/001-codex-tui-renderer-optimization/research.md
@@ -1,0 +1,174 @@
+# Research: Codex TUI Renderer Optimization
+
+## Objective
+Create an evidence-backed architecture baseline for the Codex TUI renderer and backend flow, then recommend phased optimizations and layered PR slicing.
+
+## Current-State Architecture
+
+### Renderer Flow (Current)
+
+```text
+[Terminal Input/Event Stream]
+            |
+            v
+   TuiEvent (key/paste/draw/resize)
+            |
+            v
++-------------------------------+
+| App::run main select loop     |
+| - AppEvent channel            |
+| - Codex protocol events       |
+| - TuiEvent stream             |
++-------------------------------+
+            |
+            v
+  App::handle_tui_event / handle_event
+            |
+            v
++-------------------------------+
+| ChatWidget state mutation     |
+| - history cells               |
+| - bottom pane state machine   |
+| - status + overlays           |
++-------------------------------+
+            |
+            v
+ FrameRequester::schedule_frame
+            |
+            v
+ FrameScheduler (coalesce/throttle)
+            |
+            v
+          Tui::draw
+            |
+            v
+   ratatui Terminal::draw
+   (buffer diff flush only)
+```
+
+### Backend Flow (Current)
+
+```text
+codex CLI entry
+(main.rs -> lib.rs::run_main)
+            |
+            v
+TUI App runtime (app.rs)
+            |
+            v
+ThreadManager (core)
+- thread lifecycle
+- event fan-in/out
+            |
+            v
+Codex + ModelClient session
+- provider auth/session
+- stream transport
+            |
+            v
+Responses/protocol events
+(codex_protocol Event/EventMsg)
+            |
+            v
+AppEvent + UI channels
+            |
+            v
+ChatWidget render state
+            |
+            v
+Terminal frame updates
+
+Parallel control-plane exposure:
+app-server JSON-RPC API emits the same thread/turn/item event model
+for external clients and automation.
+```
+
+## Key Findings
+1. Frame scheduling is already centralized and coalesced, which is a strong base for dirty-region and adaptive-rate improvements.
+2. Render cost is dominated by state-to-view transformation and high-frequency redraw triggers, not just terminal flush.
+3. Backend event throughput can outpace UI consumption under heavy streaming unless queue bounds and batching policies are explicit.
+4. Current architecture supports incremental optimization because render orchestration and backend protocol flow are cleanly separated.
+
+## External Optimization Evidence (Rust TUI)
+
+### Reviewed article: octorus 300K-line diff rendering
+- Multi-layer caches to separate session data, diff precompute, and active view caches.
+- Background precompute to reduce first-open latency.
+- Viewport-restricted rendering to avoid whole-document work.
+- String interning and structured token reuse to reduce allocation and memory churn.
+- Deferred/lazy composition for secondary decorations (for example, comments/markers).
+
+### Additional references and implications
+- ratatui uses double buffers and writes only changed cells, so avoid forcing full redraw semantics.
+- crossterm polling/event APIs can be used to control event loop wake behavior.
+- Tokio bounded channels provide explicit backpressure and should be preferred in high-rate producer paths.
+- Rope/interner data structures (for large text/token workloads) can constrain memory and copy overhead.
+
+## Recommended Optimization Layers
+
+### Layer 1: Observability and Baseline (low risk)
+- Add renderer timing spans by stage (event ingest, state mutation, compose, draw).
+- Add queue-depth and event-lag metrics for UI-facing channels.
+- Produce reproducible benchmark fixtures for large transcript and high-stream turns.
+
+### Layer 2: Render Work Reduction (medium risk)
+- Introduce viewport/dirty-range constrained state-to-view transformation.
+- Cache expensive layout/text shaping outputs keyed by stable state signatures.
+- Batch low-priority cosmetic updates behind frame budget checks.
+
+### Layer 3: Event Pressure Control (medium risk)
+- Enforce bounded channels on high-volume paths.
+- Add coalescing policies for bursty protocol deltas.
+- De-prioritize non-critical event classes during sustained load.
+
+### Layer 4: Data-Structure Efficiency (higher risk)
+- Evaluate rope/interner-backed buffers for large scrollback and diff-like payloads.
+- Minimize transient allocations in render preparation paths.
+- Add zero-copy borrowing contracts where lifetimes are already naturally scoped.
+
+### Layer 5: UX-Protective Progressive Rendering (higher risk)
+- Progressive display modes for large payloads (fast plain path, enriched path when ready).
+- Deferred decoration composition for non-blocking first paint.
+
+## Layered PR Strategy Draft
+
+### PR-A: Instrumentation and Benchmarks
+- Scope: metrics, traces, baseline harness, no behavior change.
+- Exit: stable measurements for frame times and event lag.
+
+### PR-B: Render Pipeline Caching + Viewport Constraint
+- Scope: reduce compose work and unnecessary redraw preparation.
+- Exit: measurable reduction in p95 frame time under heavy transcript scenarios.
+
+### PR-C: Event Backpressure + Coalescing
+- Scope: bounded channel policies and burst handling.
+- Exit: no runaway queue growth under sustained streaming.
+
+### PR-D: Large-Text Data Structure Enhancements
+- Scope: targeted interning/rope introduction where evidence shows clear benefit.
+- Exit: lower memory growth and allocation churn for large-content sessions.
+
+### PR-E: Progressive Enrichment UX
+- Scope: plain-first fast path, deferred enrichments.
+- Exit: improved first-meaningful-display latency on large payloads.
+
+## Open Questions
+- Which user workflows should define canonical performance SLOs (chat streaming, diff-like browsing, or both)?
+- Which event classes can be safely coalesced without degrading perceived responsiveness?
+- What benchmark dataset should become the long-term regression gate?
+
+## Risks
+- Premature optimization without benchmark baselines may introduce complexity with weak impact.
+- Backpressure tuning may affect perceived responsiveness if thresholds are set too aggressively.
+- Data-structure migrations can expand code complexity and require careful rollback boundaries.
+
+## Sources
+- DEV article: https://dev.to/ushironoko/how-octorus-renders-300k-lines-of-diff-at-high-speed-h4p
+- ratatui rendering concepts: https://ratatui.rs/concepts/rendering/
+- ratatui Terminal buffering: https://docs.rs/ratatui/latest/ratatui/struct.Terminal.html
+- crossterm poll API: https://docs.rs/crossterm/latest/crossterm/event/fn.poll.html
+- tokio bounded channels/backpressure: https://docs.rs/tokio/latest/tokio/sync/mpsc/index.html
+- tokio channel backpressure guidance: https://tokio.rs/tokio/tutorial/channels
+- ropey rope performance model: https://docs.rs/ropey/latest/ropey/struct.Rope.html
+- lasso interning model: https://docs.rs/lasso/latest/lasso/
+- local code: `codex-rs/tui/src/app.rs`, `codex-rs/tui/src/chatwidget.rs`, `codex-rs/tui/src/tui.rs`, `codex-rs/tui/src/tui/frame_requester.rs`, `codex-rs/core/src/thread_manager.rs`, `codex-rs/core/src/client.rs`, `codex-rs/core/src/model_provider_info.rs`, `codex-rs/app-server/README.md`

--- a/.archive/kitty-specs/001-codex-tui-renderer-optimization/research/evidence-log.csv
+++ b/.archive/kitty-specs/001-codex-tui-renderer-optimization/research/evidence-log.csv
@@ -1,0 +1,7 @@
+evidence_id,source_id,claim,claim_type,confidence,notes
+E-001,SRC-EXT-001,"octorus uses layered caching and viewport-restricted rendering to keep large diff interaction responsive",external-observation,high,"From DEV article summary"
+E-002,SRC-EXT-003,"ratatui Terminal compares current and previous buffers and writes only diffs",external-fact,high,"Direct API documentation behavior"
+E-003,SRC-INT-001,"App::run funnels AppEvent, protocol event, and TuiEvent streams in one select loop",internal-architecture,high,"app.rs line references"
+E-004,SRC-INT-002,"ChatWidget centralizes state mutation before render and key handling",internal-architecture,high,"chatwidget.rs line references"
+E-005,SRC-EXT-005,"bounded tokio mpsc channels provide backpressure under load",external-fact,high,"tokio docs"
+E-006,SRC-EXT-007,"rope-based text storage offers O(log N) operations for large texts",external-fact,medium,"ropey docs"

--- a/.archive/kitty-specs/001-codex-tui-renderer-optimization/research/source-register.csv
+++ b/.archive/kitty-specs/001-codex-tui-renderer-optimization/research/source-register.csv
@@ -1,0 +1,17 @@
+source_id,source_type,title_or_path,url_or_path,accessed_utc,relevance
+SRC-EXT-001,web,"How octorus Renders 300K Lines of Diff at High Speed",https://dev.to/ushironoko/how-octorus-renders-300k-lines-of-diff-at-high-speed-h4p,2026-02-28T00:00:00Z,high
+SRC-EXT-002,web,"Ratatui Rendering Concepts",https://ratatui.rs/concepts/rendering/,2026-02-28T00:00:00Z,high
+SRC-EXT-003,web,"ratatui::Terminal docs",https://docs.rs/ratatui/latest/ratatui/struct.Terminal.html,2026-02-28T00:00:00Z,high
+SRC-EXT-004,web,"crossterm poll docs",https://docs.rs/crossterm/latest/crossterm/event/fn.poll.html,2026-02-28T00:00:00Z,medium
+SRC-EXT-005,web,"tokio mpsc docs",https://docs.rs/tokio/latest/tokio/sync/mpsc/index.html,2026-02-28T00:00:00Z,high
+SRC-EXT-006,web,"tokio channels tutorial",https://tokio.rs/tokio/tutorial/channels,2026-02-28T00:00:00Z,medium
+SRC-EXT-007,web,"ropey Rope docs",https://docs.rs/ropey/latest/ropey/struct.Rope.html,2026-02-28T00:00:00Z,medium
+SRC-EXT-008,web,"lasso docs",https://docs.rs/lasso/latest/lasso/,2026-02-28T00:00:00Z,medium
+SRC-INT-001,code,"codex-rs/tui/src/app.rs",/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/codex-rs/tui/src/app.rs,2026-02-28T00:00:00Z,high
+SRC-INT-002,code,"codex-rs/tui/src/chatwidget.rs",/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/codex-rs/tui/src/chatwidget.rs,2026-02-28T00:00:00Z,high
+SRC-INT-003,code,"codex-rs/tui/src/tui.rs",/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/codex-rs/tui/src/tui.rs,2026-02-28T00:00:00Z,high
+SRC-INT-004,code,"codex-rs/tui/src/tui/frame_requester.rs",/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/codex-rs/tui/src/tui/frame_requester.rs,2026-02-28T00:00:00Z,high
+SRC-INT-005,code,"codex-rs/core/src/thread_manager.rs",/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/codex-rs/core/src/thread_manager.rs,2026-02-28T00:00:00Z,high
+SRC-INT-006,code,"codex-rs/core/src/client.rs",/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/codex-rs/core/src/client.rs,2026-02-28T00:00:00Z,high
+SRC-INT-007,code,"codex-rs/core/src/model_provider_info.rs",/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/codex-rs/core/src/model_provider_info.rs,2026-02-28T00:00:00Z,high
+SRC-INT-008,doc,"codex-rs/app-server/README.md",/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/codex-rs/app-server/README.md,2026-02-28T00:00:00Z,high

--- a/.archive/kitty-specs/001-codex-tui-renderer-optimization/spec.md
+++ b/.archive/kitty-specs/001-codex-tui-renderer-optimization/spec.md
@@ -1,0 +1,74 @@
+# Feature Specification: Codex TUI Renderer Optimization
+
+**Feature Branch**: `001-codex-tui-renderer-optimization`  
+**Created**: 2026-02-28  
+**Status**: Draft  
+**Mission**: research
+
+## Summary
+Produce a research-grade architecture walkthrough of the current Codex TUI renderer and its backend event/runtime architecture, then define a layered optimization roadmap informed by octorus and Rust TUI performance practices.
+
+## Problem Statement
+Current renderer and backend behavior are distributed across multiple modules, making it hard to reason about frame scheduling, event flow, and optimization leverage points. This blocks reliable prioritization for high-impact performance work.
+
+## Goals
+- Deliver an architecture walkthrough for current TUI rendering and backend event flow.
+- Provide ASCII diagrams that can be used directly in planning and PR discussions.
+- Produce optimization research grounded in concrete evidence and source tracking.
+- Define a layered PR strategy that can be executed incrementally with clear outcomes.
+
+## Non-Goals
+- Implementing renderer changes in this feature.
+- Executing benchmark harness changes in this feature.
+- Merging any runtime refactor in this feature.
+
+## Actors
+- CLI maintainers prioritizing performance work.
+- Agent implementers executing follow-on layered PRs.
+- Reviewers validating architecture and optimization rationale.
+
+## User Scenarios & Testing
+### Primary Scenario
+A maintainer needs a trusted architecture baseline and optimization sequence before authoring implementation PRs.
+
+### Acceptance Scenarios
+1. Given the feature artifacts, maintainers can trace render lifecycle from input event to frame flush.
+2. Given the backend diagram, maintainers can trace how model events become UI updates.
+3. Given optimization findings, maintainers can identify phased PRs with measurable expected impact.
+4. Given source logs, reviewers can audit every major claim against recorded evidence.
+
+## Functional Requirements
+- **FR-001**: The feature MUST provide a current-state TUI renderer architecture walkthrough.
+- **FR-002**: The feature MUST provide a current-state backend architecture walkthrough relevant to TUI rendering.
+- **FR-003**: The feature MUST include ASCII diagrams for both renderer and backend flows.
+- **FR-004**: The feature MUST capture optimization opportunities prioritized by expected user-visible impact.
+- **FR-005**: The feature MUST include a layered PR strategy with explicit sequencing and dependency intent.
+- **FR-006**: The feature MUST maintain an auditable evidence trail with source register and finding log.
+- **FR-007**: The feature MUST record open questions and risks for follow-on planning.
+
+## Success Criteria
+- 100% of major architecture claims map to at least one source entry in the evidence logs.
+- Maintainers can identify at least 3 independent optimization PR layers without additional discovery.
+- The produced diagrams are sufficient for review discussion without requiring code navigation for basic flow understanding.
+- At least 5 optimization recommendations are ranked with rationale and expected impact class.
+
+## Key Entities
+- **Renderer Path**: Ordered stages from input/event to frame scheduling and terminal flush.
+- **Backend Event Path**: Ordered stages from protocol/model events to UI state updates.
+- **Optimization Candidate**: A measurable improvement hypothesis with impact and risk level.
+- **Layered PR Slice**: A bounded change unit in a dependency-aware sequence.
+- **Evidence Entry**: A traceable source-backed finding record.
+
+## Dependencies
+- Access to current `heliosCLI` codebase paths under `codex-rs/`.
+- Public references for Rust TUI optimization practices.
+
+## Assumptions
+- Target branch for follow-on execution is `main`.
+- This feature remains research-only and does not include code behavior changes.
+- Layered PR execution will be performed in a later implementation phase.
+
+## Risks
+- Architecture drift if code changes significantly before follow-on PRs begin.
+- Overfitting recommendations to one workload profile without benchmark baselines.
+


### PR DESCRIPTION
## Summary
- Migrates kitty-specs/001-codex-tui-renderer-optimization to `.agileplus/specs/` format
- Archives original `kitty-specs/` to `.archive/kitty-specs/`
- CLAUDE.md already references AgilePlus, no changes needed

## Changes
- `.agileplus/specs/001-codex-tui-renderer-optimization/` (spec.md, meta.json, tasks.md)
- `.archive/kitty-specs/001-codex-tui-renderer-optimization/` (archived original)