### PR TITLE
fix(workspace): replace broken symlink member with actual crate members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,25 @@
 [workspace]
 resolver = "2"
 members = [
-    # Native extensions (these can be built)
-    "crates/harness-native",
-    ]
+    "crates/arch_test",
+    "crates/harness_cache",
+    "crates/harness_checkpoint",
+    "crates/harness_discoverer",
+    "crates/harness_elicitation",
+    "crates/harness_interfaces",
+    "crates/harness_normalizer",
+    "crates/harness_orchestrator",
+    "crates/harness_pyo3",
+    "crates/harness_queue",
+    "crates/harness_rollback",
+    "crates/harness_runner",
+    "crates/harness_scaling",
+    "crates/harness_schema",
+    "crates/harness_spec",
+    "crates/harness_teammates",
+    "crates/harness_utils",
+    "crates/harness_verify",
+]
 
 [workspace.package]
 name = "helios"


### PR DESCRIPTION
## Summary
- Workspace `Cargo.toml` listed `crates/harness-native` as a member, which was a broken symlink pointing to `../../heliosHarness/crates/harness-native` (a sibling repo not present in this checkout)
- `cargo check` and `cargo build` failed with: `The manifest is virtual, and the workspace has no members.`
- Fix: update workspace `members` list to the 18 actual Rust crates present in `crates/` (all using underscore naming convention), removing the stale broken-symlink entry

## Test plan
- [x] `cargo check --workspace` passes (`Finished dev profile`)
- [x] All 18 crates compile cleanly: arch_test, harness_cache, harness_checkpoint, harness_discoverer, harness_elicitation, harness_interfaces, harness_normalizer, harness_orchestrator, harness_pyo3, harness_queue, harness_rollback, harness_runner, harness_scaling, harness_schema, harness_spec, harness_teammates, harness_utils, harness_verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)