### PR TITLE
fix: replace deprecated criterion::black_box with std::hint::black_box

### DIFF
--- a/crates/harness_cache/benches/cache_bench.rs
+++ b/crates/harness_cache/benches/cache_bench.rs
@@ -1,7 +1,8 @@
 //! Benchmark tests for harness_cache
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use harness_cache::Cache;
+use std::hint::black_box;
 
 fn bench_cache_get(c: &mut Criterion) {
     let cache = Cache::with_defaults();


### PR DESCRIPTION
Fixes deprecation warning in cache_bench.rs.