### PR TITLE
docs: add Phenotype Fork Differentiation section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ If you want Codex in your code editor (VS Code, Cursor, Windsurf), <a href="http
 </br>If you want the desktop app experience, run <code>codex app</code> or visit <a href="https://chatgpt.com/codex?app-landing-page=true">the Codex App page</a>.
 </br>If you are looking for the <em>cloud-based agent</em> from OpenAI, <strong>Codex Web</strong>, go to <a href="https://chatgpt.com/codex">chatgpt.com/codex</a>.</p>
 
+## Phenotype Fork Differentiation
+
+This is the **Phenotype community fork** of `openai/codex` (`rust-v0.105.0`). Key enhancements:
+
+- **Full spec documentation**: TUI architecture decomposition, renderer optimization, and chat composer refactoring tracked in `docs/specs/` (AgilePlus format)
+- **Multi-crate harness system**: 20+ harness crates for validation, caching, checkpointing, discovery, and resilience (via `heliosHarness` workspace)
+- **Trait-based TDD refactoring**: Extracted `Renderable`, `Submitter`, `HistoryNavigator`, and `KeyEventRouter` traits to enable modular testing (kitty-specs Phase 1-6)
+- **Phenotype governance integration**: Full ADR, FR, and code entity mapping in `docs/` with @phenotype/docs integration
+- **VitePress docsite**: Self-hosted documentation with architecture guides and validation harness reference
+
+**Syncing upstream**: Rebase against `openai/codex` main branch using `git pull --rebase origin main` and resolve conflicts in `harness_*` crates.
+
+
 ---
 
 ## Quickstart


### PR DESCRIPTION
## Summary

This PR adds a "Phenotype Fork Differentiation" section to the README that clearly describes how this fork differs from the upstream `openai/codex` repository.

## Changes

- Added fork differentiation section after the intro, before Quickstart
- Documents 5 key technical enhancements made in the Phenotype fork
- Includes strategy for syncing upstream changes

## Key Enhancements Documented

1. **Full spec documentation** — AgilePlus format architecture docs in `docs/specs/`
2. **Multi-crate harness system** — 20+ validation/caching/discovery crates via `heliosHarness`
3. **Trait-based TDD refactoring** — Modular Renderable, Submitter, HistoryNavigator, KeyEventRouter traits
4. **Phenotype governance integration** — Full ADR and FR mappings in `docs/`
5. **VitePress docsite** — Self-hosted documentation with architecture guides

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>