### PR TITLE
chore: rescue temp dir unpushed commits (WIP codex-rs + artifacts)

### DIFF
--- a/codex-rs/core/src/auth.rs
+++ b/codex-rs/core/src/auth.rs
@@ -299,7 +299,7 @@ impl CodexAuth {
             Self::ApiKey(_) => return None,
         };
         #[expect(clippy::unwrap_used)]
-        state.auth_dot_json.lock().unwrap().clone()
+        state.auth_dot_json.lock().expect("mutex lock").clone()
     }
 
     /// Returns `None` if `is_chatgpt_auth()` is false.
@@ -344,7 +344,7 @@ impl CodexAuth {
 impl ChatgptAuth {
     fn current_auth_json(&self) -> Option<AuthDotJson> {
         #[expect(clippy::unwrap_used)]
-        self.state.auth_dot_json.lock().unwrap().clone()
+        self.state.auth_dot_json.lock().expect("mutex lock").clone()
     }
 
     fn current_token_data(&self) -> Option<TokenData> {
@@ -1378,7 +1378,7 @@ mod tests {
 
     #[tokio::test]
     async fn refresh_without_id_token() {
-        let codex_home = tempdir().unwrap();
+        let codex_home = tempdir().expect("codex_home tempdir");
         let fake_jwt = write_auth_file(
             AuthFileParams {
                 openai_api_key: None,
@@ -1409,7 +1409,7 @@ mod tests {
 
     #[test]
     fn login_with_api_key_overwrites_existing_auth_json() {
-        let dir = tempdir().unwrap();
+        let dir = tempdir().expect("dir tempdir");
         let auth_path = dir.path().join("auth.json");
         let stale_auth = json!({
             "OPENAI_API_KEY": "sk-old",
@@ -1422,10 +1422,10 @@ mod tests {
         });
         std::fs::write(
             &auth_path,
-            serde_json::to_string_pretty(&stale_auth).unwrap(),
+            serde_json::to_string_pretty(&stale_auth).expect("serialize auth"),
         )
-        .unwrap();
-
+        .expect("write auth json")
+        .expect("flush auth json");
         super::login_with_api_key(dir.path(), "sk-new", AuthCredentialsStoreMode::File)
             .expect("login_with_api_key should succeed");
 
@@ -1439,7 +1439,7 @@ mod tests {
 
     #[test]
     fn missing_auth_json_returns_none() {
-        let dir = tempdir().unwrap();
+        let dir = tempdir().expect("dir tempdir");
         let auth = CodexAuth::from_auth_storage(dir.path(), AuthCredentialsStoreMode::File)
             .expect("call should succeed");
         assert_eq!(auth, None);
@@ -1448,7 +1448,7 @@ mod tests {
     #[tokio::test]
     #[serial(codex_api_key)]
     async fn pro_account_with_no_api_key_uses_chatgpt_auth() {
-        let codex_home = tempdir().unwrap();
+        let codex_home = tempdir().expect("codex_home tempdir");
         let fake_jwt = write_auth_file(
             AuthFileParams {
                 openai_api_key: None,
@@ -1460,8 +1460,8 @@ mod tests {
         .expect("failed to write auth file");
 
         let auth = super::load_auth(codex_home.path(), false, AuthCredentialsStoreMode::File)
-            .unwrap()
-            .unwrap();
+            .expect("load auth")
+            .expect("auth should exist");
         assert_eq!(None, auth.api_key());
         assert_eq!(AuthMode::Chatgpt, auth.auth_mode());
 
@@ -1497,17 +1497,17 @@ mod tests {
     #[tokio::test]
     #[serial(codex_api_key)]
     async fn loads_api_key_from_auth_json() {
-        let dir = tempdir().unwrap();
+        let dir = tempdir().expect("dir tempdir");
         let auth_file = dir.path().join("auth.json");
         std::fs::write(
             auth_file,
             r#"{"OPENAI_API_KEY":"sk-test-key","tokens":null,"last_refresh":null}"#,
         )
-        .unwrap();
-
+        .expect("write auth json")
+        .expect("flush auth json");
         let auth = super::load_auth(dir.path(), false, AuthCredentialsStoreMode::File)
-            .unwrap()
-            .unwrap();
+            .expect("load auth")
+            .expect("auth should exist");
         assert_eq!(auth.auth_mode(), AuthMode::ApiKey);
         assert_eq!(auth.api_key(), Some("sk-test-key"));
 
@@ -1636,7 +1636,7 @@ mod tests {
 
     #[tokio::test]
     async fn enforce_login_restrictions_logs_out_for_method_mismatch() {
-        let codex_home = tempdir().unwrap();
+        let codex_home = tempdir().expect("codex_home tempdir");
         login_with_api_key(codex_home.path(), "sk-test", AuthCredentialsStoreMode::File)
             .expect("seed api key");
 
@@ -1654,7 +1654,7 @@ mod tests {
     #[tokio::test]
     #[serial(codex_api_key)]
     async fn enforce_login_restrictions_logs_out_for_workspace_mismatch() {
-        let codex_home = tempdir().unwrap();
+        let codex_home = tempdir().expect("codex_home tempdir");
         let _jwt = write_auth_file(
             AuthFileParams {
                 openai_api_key: None,
@@ -1679,7 +1679,7 @@ mod tests {
     #[tokio::test]
     #[serial(codex_api_key)]
     async fn enforce_login_restrictions_allows_matching_workspace() {
-        let codex_home = tempdir().unwrap();
+        let codex_home = tempdir().expect("codex_home tempdir");
         let _jwt = write_auth_file(
             AuthFileParams {
                 openai_api_key: None,
@@ -1702,7 +1702,7 @@ mod tests {
     #[tokio::test]
     async fn enforce_login_restrictions_allows_api_key_if_login_method_not_set_but_forced_chatgpt_workspace_id_is_set()
      {
-        let codex_home = tempdir().unwrap();
+        let codex_home = tempdir().expect("codex_home tempdir");
         login_with_api_key(codex_home.path(), "sk-test", AuthCredentialsStoreMode::File)
             .expect("seed api key");
 
@@ -1719,7 +1719,7 @@ mod tests {
     #[serial(codex_api_key)]
     async fn enforce_login_restrictions_blocks_env_api_key_when_chatgpt_required() {
         let _guard = EnvVarGuard::set(CODEX_API_KEY_ENV_VAR, "sk-env");
-        let codex_home = tempdir().unwrap();
+        let codex_home = tempdir().expect("codex_home tempdir");
 
         let config = build_config(codex_home.path(), Some(ForcedLoginMethod::Chatgpt), None).await;
 
@@ -1733,7 +1733,7 @@ mod tests {
 
     #[test]
     fn plan_type_maps_known_plan() {
-        let codex_home = tempdir().unwrap();
+        let codex_home = tempdir().expect("codex_home tempdir");
         let _jwt = write_auth_file(
             AuthFileParams {
                 openai_api_key: None,
@@ -1753,7 +1753,7 @@ mod tests {
 
     #[test]
     fn plan_type_maps_unknown_to_unknown() {
-        let codex_home = tempdir().unwrap();
+        let codex_home = tempdir().expect("codex_home tempdir");
         let _jwt = write_auth_file(
             AuthFileParams {
                 openai_api_key: None,
@@ -1773,7 +1773,7 @@ mod tests {
 
     #[test]
     fn missing_plan_type_maps_to_unknown() {
-        let codex_home = tempdir().unwrap();
+        let codex_home = tempdir().expect("codex_home tempdir");
         let _jwt = write_auth_file(
             AuthFileParams {
                 openai_api_key: None,

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -7762,7 +7762,7 @@ mod tests {
                     "ok": true,
                     "value": 42
                 }))
-                .unwrap(),
+                .expect("serialize json value"),
             ),
             success: Some(true),
         };
@@ -7840,7 +7840,7 @@ mod tests {
         let got = FunctionCallOutputPayload::from(&ctr);
         let expected = FunctionCallOutputPayload {
             body: FunctionCallOutputBody::Text(
-                serde_json::to_string(&vec![text_block("hello"), text_block("world")]).unwrap(),
+                serde_json::to_string(&vec![text_block("hello"), text_block("world")]).expect("serialize text blocks"),
             ),
             success: Some(true),
         };
@@ -7860,7 +7860,7 @@ mod tests {
         let got = FunctionCallOutputPayload::from(&ctr);
         let expected = FunctionCallOutputPayload {
             body: FunctionCallOutputBody::Text(
-                serde_json::to_string(&json!({ "message": "bad" })).unwrap(),
+                serde_json::to_string(&json!({ "message": "bad" })).expect("serialize error message"),
             ),
             success: Some(false),
         };
@@ -7880,7 +7880,7 @@ mod tests {
         let got = FunctionCallOutputPayload::from(&ctr);
         let expected = FunctionCallOutputPayload {
             body: FunctionCallOutputBody::Text(
-                serde_json::to_string(&vec![text_block("alpha")]).unwrap(),
+                serde_json::to_string(&vec![text_block("alpha")]).expect("serialize text blocks"),
             ),
             success: Some(true),
         };
@@ -9128,7 +9128,8 @@ mod tests {
             "expected TurnAborted after abort"
         );
         assert!(
-            exited_review_mode_idx.unwrap() < turn_aborted_idx.unwrap(),
+            exited_review_mode_idx.expect("exited review mode")
+                < turn_aborted_idx.expect("turn aborted"),
             "expected ExitedReviewMode before TurnAborted"
         );
 

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -3010,7 +3010,7 @@ trust_level = "trusted"
             temp_dir.path().to_path_buf(),
         )?;
 
-        let expected_backend = AbsolutePathBuf::try_from(backend).unwrap();
+        let expected_backend = AbsolutePathBuf::try_from(backend).expect("backend path should be valid");
         if cfg!(target_os = "windows") {
             match config.permissions.sandbox_policy.get() {
                 SandboxPolicy::ReadOnly { .. } => {}
@@ -4784,13 +4784,13 @@ model_verbosity = "high"
 
         // Use a temporary directory for the cwd so it does not contain an
         // AGENTS.md file.
-        let cwd_temp_dir = TempDir::new().unwrap();
+        let cwd_temp_dir = TempDir::new().expect("tempdir");
         let cwd = cwd_temp_dir.path().to_path_buf();
         // Make it look like a Git repo so it does not search for AGENTS.md in
         // a parent folder, either.
         std::fs::write(cwd.join(".git"), "gitdir: nowhere")?;
 
-        let codex_home_temp_dir = TempDir::new().unwrap();
+        let codex_home_temp_dir = TempDir::new().expect("codex_home tempdir");
 
         let openai_custom_provider = ModelProviderInfo {
             name: "OpenAI custom".to_string(),

--- a/codex-rs/core/src/config/service.rs
+++ b/codex-rs/core/src/config/service.rs
@@ -868,11 +868,11 @@ personality = true
     async fn read_includes_origins_and_layers() {
         let tmp = tempdir().expect("tempdir");
         let user_path = tmp.path().join(CONFIG_TOML_FILE);
-        std::fs::write(&user_path, "model = \"user\"").unwrap();
+        std::fs::write(&user_path, "model = \"user\"").expect("write user config");
         let user_file = AbsolutePathBuf::try_from(user_path.clone()).expect("user file");
 
         let managed_path = tmp.path().join("managed_config.toml");
-        std::fs::write(&managed_path, "approval_policy = \"never\"").unwrap();
+        std::fs::write(&managed_path, "approval_policy = \"never\"").expect("write managed config");
         let managed_file = AbsolutePathBuf::try_from(managed_path.clone()).expect("managed file");
 
         let service = ConfigService::new(
@@ -920,19 +920,19 @@ personality = true
         };
         assert_eq!(layers.len(), 3, "expected three layers");
         assert_eq!(
-            layers.first().unwrap().name,
+            layers.first().expect("layer 0").name,
             ConfigLayerSource::LegacyManagedConfigTomlFromFile {
                 file: managed_file.clone()
             }
         );
         assert_eq!(
-            layers.get(1).unwrap().name,
+            layers.get(1).expect("layer 1").name,
             ConfigLayerSource::User {
                 file: user_file.clone()
             }
         );
         assert!(matches!(
-            layers.get(2).unwrap().name,
+            layers.get(2).expect("layer 2").name,
             ConfigLayerSource::System { .. }
         ));
     }
@@ -944,10 +944,10 @@ personality = true
             tmp.path().join(CONFIG_TOML_FILE),
             "approval_policy = \"on-request\"",
         )
-        .unwrap();
+        .expect("write approval config");
 
         let managed_path = tmp.path().join("managed_config.toml");
-        std::fs::write(&managed_path, "approval_policy = \"never\"").unwrap();
+        std::fs::write(&managed_path, "approval_policy = \"never\"").expect("write managed config");
         let managed_file = AbsolutePathBuf::try_from(managed_path.clone()).expect("managed file");
 
         let service = ConfigService::new(
@@ -1002,7 +1002,7 @@ personality = true
     async fn version_conflict_rejected() {
         let tmp = tempdir().expect("tempdir");
         let user_path = tmp.path().join(CONFIG_TOML_FILE);
-        std::fs::write(&user_path, "model = \"user\"").unwrap();
+        std::fs::write(&user_path, "model = \"user\"").expect("write user config");
 
         let service = ConfigService::new_with_defaults(tmp.path().to_path_buf());
         let error = service
@@ -1025,7 +1025,7 @@ personality = true
     #[tokio::test]
     async fn write_value_defaults_to_user_config_path() {
         let tmp = tempdir().expect("tempdir");
-        std::fs::write(tmp.path().join(CONFIG_TOML_FILE), "").unwrap();
+        std::fs::write(tmp.path().join(CONFIG_TOML_FILE), "").expect("write empty config");
 
         let service = ConfigService::new_with_defaults(tmp.path().to_path_buf());
         service
@@ -1050,10 +1050,10 @@ personality = true
     #[tokio::test]
     async fn invalid_user_value_rejected_even_if_overridden_by_managed() {
         let tmp = tempdir().expect("tempdir");
-        std::fs::write(tmp.path().join(CONFIG_TOML_FILE), "model = \"user\"").unwrap();
+        std::fs::write(tmp.path().join(CONFIG_TOML_FILE), "model = \"user\"").expect("write config");
 
         let managed_path = tmp.path().join("managed_config.toml");
-        std::fs::write(&managed_path, "approval_policy = \"never\"").unwrap();
+        std::fs::write(&managed_path, "approval_policy = \"never\"").expect("write managed config");
 
         let service = ConfigService::new(
             tmp.path().to_path_buf(),
@@ -1092,11 +1092,11 @@ personality = true
     async fn read_reports_managed_overrides_user_and_session_flags() {
         let tmp = tempdir().expect("tempdir");
         let user_path = tmp.path().join(CONFIG_TOML_FILE);
-        std::fs::write(&user_path, "model = \"user\"").unwrap();
+        std::fs::write(&user_path, "model = \"user\"").expect("write user config");
         let user_file = AbsolutePathBuf::try_from(user_path.clone()).expect("user file");
 
         let managed_path = tmp.path().join("managed_config.toml");
-        std::fs::write(&managed_path, "model = \"system\"").unwrap();
+        std::fs::write(&managed_path, "model = \"system\"").expect("write managed model config");
         let managed_file = AbsolutePathBuf::try_from(managed_path.clone()).expect("managed file");
 
         let cli_overrides = vec![(
@@ -1143,12 +1143,12 @@ personality = true
             layers.as_slice()
         };
         assert_eq!(
-            layers.first().unwrap().name,
+            layers.first().expect("layer 0").name,
             ConfigLayerSource::LegacyManagedConfigTomlFromFile { file: managed_file }
         );
-        assert_eq!(layers.get(1).unwrap().name, ConfigLayerSource::SessionFlags);
+        assert_eq!(layers.get(1).expect("layer 1").name, ConfigLayerSource::SessionFlags);
         assert_eq!(
-            layers.get(2).unwrap().name,
+            layers.get(2).expect("layer 2").name,
             ConfigLayerSource::User { file: user_file }
         );
     }
@@ -1156,10 +1156,10 @@ personality = true
     #[tokio::test]
     async fn write_value_reports_managed_override() {
         let tmp = tempdir().expect("tempdir");
-        std::fs::write(tmp.path().join(CONFIG_TOML_FILE), "").unwrap();
+        std::fs::write(tmp.path().join(CONFIG_TOML_FILE), "").expect("write empty config");
 
         let managed_path = tmp.path().join("managed_config.toml");
-        std::fs::write(&managed_path, "approval_policy = \"never\"").unwrap();
+        std::fs::write(&managed_path, "approval_policy = \"never\"").expect("write managed config");
         let managed_file = AbsolutePathBuf::try_from(managed_path.clone()).expect("managed file");
 
         let service = ConfigService::new(

--- a/codex-rs/core/src/context_manager/history_tests.rs
+++ b/codex-rs/core/src/context_manager/history_tests.rs
@@ -1300,7 +1300,7 @@ fn image_data_url_payload_does_not_dominate_message_estimate() {
         phase: None,
     };
 
-    let raw_len = serde_json::to_string(&image_item).unwrap().len() as i64;
+    let raw_len = serde_json::to_string(&image_item).expect("serialize image item").len() as i64;
     let estimated = estimate_response_item_model_visible_bytes(&image_item);
     let expected = raw_len - payload.len() as i64 + IMAGE_BYTES_ESTIMATE;
     let text_only_estimated = estimate_response_item_model_visible_bytes(&text_only_item);
@@ -1324,7 +1324,7 @@ fn image_data_url_payload_does_not_dominate_function_call_output_estimate() {
         ]),
     };
 
-    let raw_len = serde_json::to_string(&item).unwrap().len() as i64;
+    let raw_len = serde_json::to_string(&item).expect("serialize item").len() as i64;
     let estimated = estimate_response_item_model_visible_bytes(&item);
     let expected = raw_len - payload.len() as i64 + IMAGE_BYTES_ESTIMATE;
 
@@ -1346,7 +1346,7 @@ fn image_data_url_payload_does_not_dominate_custom_tool_call_output_estimate() {
         ]),
     };
 
-    let raw_len = serde_json::to_string(&item).unwrap().len() as i64;
+    let raw_len = serde_json::to_string(&item).expect("serialize item").len() as i64;
     let estimated = estimate_response_item_model_visible_bytes(&item);
     let expected = raw_len - payload.len() as i64 + IMAGE_BYTES_ESTIMATE;
 
@@ -1376,11 +1376,11 @@ fn non_base64_image_urls_are_unchanged() {
 
     assert_eq!(
         estimate_response_item_model_visible_bytes(&message_item),
-        serde_json::to_string(&message_item).unwrap().len() as i64
+        serde_json::to_string(&message_item).expect("serialize message item").len() as i64
     );
     assert_eq!(
         estimate_response_item_model_visible_bytes(&function_output_item),
-        serde_json::to_string(&function_output_item).unwrap().len() as i64
+        serde_json::to_string(&function_output_item).expect("serialize function output item").len() as i64
     );
 }
 
@@ -1398,7 +1398,7 @@ fn data_url_without_base64_marker_is_unchanged() {
 
     assert_eq!(
         estimate_response_item_model_visible_bytes(&item),
-        serde_json::to_string(&item).unwrap().len() as i64
+        serde_json::to_string(&item).expect("serialize item").len() as i64
     );
 }
 
@@ -1413,7 +1413,7 @@ fn non_image_base64_data_url_is_unchanged() {
         ]),
     };
 
-    let raw_len = serde_json::to_string(&item).unwrap().len() as i64;
+    let raw_len = serde_json::to_string(&item).expect("serialize item").len() as i64;
     let estimated = estimate_response_item_model_visible_bytes(&item);
 
     assert_eq!(estimated, raw_len);
@@ -1431,7 +1431,7 @@ fn mixed_case_data_url_markers_are_adjusted() {
         phase: None,
     };
 
-    let raw_len = serde_json::to_string(&item).unwrap().len() as i64;
+    let raw_len = serde_json::to_string(&item).expect("serialize item").len() as i64;
     let estimated = estimate_response_item_model_visible_bytes(&item);
     let expected = raw_len - payload.len() as i64 + IMAGE_BYTES_ESTIMATE;
 
@@ -1462,7 +1462,7 @@ fn multiple_inline_images_apply_multiple_fixed_costs() {
         phase: None,
     };
 
-    let raw_len = serde_json::to_string(&item).unwrap().len() as i64;
+    let raw_len = serde_json::to_string(&item).expect("serialize item").len() as i64;
     let payload_sum = (payload_one.len() + payload_two.len()) as i64;
     let estimated = estimate_response_item_model_visible_bytes(&item);
     let expected = raw_len - payload_sum + (2 * IMAGE_BYTES_ESTIMATE);
@@ -1483,7 +1483,7 @@ fn text_only_items_unchanged() {
     };
 
     let estimated = estimate_response_item_model_visible_bytes(&item);
-    let raw_len = serde_json::to_string(&item).unwrap().len() as i64;
+    let raw_len = serde_json::to_string(&item).expect("serialize item").len() as i64;
 
     assert_eq!(estimated, raw_len);
 }

--- a/codex-rs/core/src/default_client.rs
+++ b/codex-rs/core/src/default_client.rs
@@ -292,19 +292,19 @@ mod tests {
         let originator_header = headers
             .get("originator")
             .expect("originator header missing");
-        assert_eq!(originator_header.to_str().unwrap(), originator().value);
+        assert_eq!(originator_header.to_str().expect("originator header value"), originator().value);
 
         // User-Agent matches the computed Codex UA for that originator
         let expected_ua = get_codex_user_agent();
         let ua_header = headers
             .get("user-agent")
             .expect("user-agent header missing");
-        assert_eq!(ua_header.to_str().unwrap(), expected_ua);
+        assert_eq!(ua_header.to_str().expect("user-agent header value"), expected_ua);
 
         let residency_header = headers
             .get(RESIDENCY_HEADER_NAME)
             .expect("residency header missing");
-        assert_eq!(residency_header.to_str().unwrap(), "us");
+        assert_eq!(residency_header.to_str().expect("residency header value"), "us");
 
         set_default_client_residency_requirement(None);
     }
@@ -340,7 +340,7 @@ mod tests {
         let re = Regex::new(&format!(
             r"^{originator}/\d+\.\d+\.\d+ \(Mac OS \d+\.\d+\.\d+; (x86_64|arm64)\) (\S+)$"
         ))
-        .unwrap();
+        .expect("valid regex");
         assert!(re.is_match(&user_agent));
     }
 }

--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -672,11 +672,13 @@ mod tests {
     fn rate_limit_snapshot() -> RateLimitSnapshot {
         let primary_reset_at = Utc
             .with_ymd_and_hms(2024, 1, 1, 1, 0, 0)
-            .unwrap()
+            .single()
+            .expect("primary reset timestamp should be valid")
             .timestamp();
         let secondary_reset_at = Utc
             .with_ymd_and_hms(2024, 1, 1, 2, 0, 0)
-            .unwrap()
+            .single()
+            .expect("secondary reset timestamp should be valid")
             .timestamp();
         RateLimitSnapshot {
             limit_id: None,
@@ -783,9 +785,9 @@ mod tests {
     fn to_error_event_handles_response_stream_failed() {
         let response = http::Response::builder()
             .status(StatusCode::TOO_MANY_REQUESTS)
-            .url(Url::parse("http://example.com").unwrap())
+            .url(Url::parse("http://example.com").expect("valid url"))
             .body("")
-            .unwrap();
+            .expect("response body");
         let source = Response::from(response).error_for_status_ref().unwrap_err();
         let err = CodexErr::ResponseStreamFailed(ResponseStreamFailed {
             source,
@@ -870,7 +872,7 @@ mod tests {
 
     #[test]
     fn usage_limit_reached_error_formats_team_plan() {
-        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).expect("valid timestamp");
         let resets_at = base + ChronoDuration::hours(1);
         with_now_override(base, move || {
             let expected_time = format_retry_timestamp(&resets_at);
@@ -917,7 +919,7 @@ mod tests {
 
     #[test]
     fn usage_limit_reached_error_formats_pro_plan_with_reset() {
-        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).expect("valid timestamp");
         let resets_at = base + ChronoDuration::hours(1);
         with_now_override(base, move || {
             let expected_time = format_retry_timestamp(&resets_at);
@@ -936,7 +938,7 @@ mod tests {
 
     #[test]
     fn usage_limit_reached_error_hides_upsell_for_non_codex_limit_name() {
-        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).expect("valid timestamp");
         let resets_at = base + ChronoDuration::hours(1);
         with_now_override(base, move || {
             let expected_time = format_retry_timestamp(&resets_at);
@@ -962,7 +964,7 @@ mod tests {
 
     #[test]
     fn usage_limit_reached_includes_minutes_when_available() {
-        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).expect("valid timestamp");
         let resets_at = base + ChronoDuration::minutes(5);
         with_now_override(base, move || {
             let expected_time = format_retry_timestamp(&resets_at);
@@ -1071,7 +1073,7 @@ mod tests {
 
     #[test]
     fn usage_limit_reached_includes_hours_and_minutes() {
-        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).expect("valid timestamp");
         let resets_at = base + ChronoDuration::hours(3) + ChronoDuration::minutes(32);
         with_now_override(base, move || {
             let expected_time = format_retry_timestamp(&resets_at);
@@ -1090,7 +1092,7 @@ mod tests {
 
     #[test]
     fn usage_limit_reached_includes_days_hours_minutes() {
-        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).expect("valid timestamp");
         let resets_at =
             base + ChronoDuration::days(2) + ChronoDuration::hours(3) + ChronoDuration::minutes(5);
         with_now_override(base, move || {
@@ -1108,7 +1110,7 @@ mod tests {
 
     #[test]
     fn usage_limit_reached_less_than_minute() {
-        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).expect("valid timestamp");
         let resets_at = base + ChronoDuration::seconds(30);
         with_now_override(base, move || {
             let expected_time = format_retry_timestamp(&resets_at);
@@ -1125,7 +1127,7 @@ mod tests {
 
     #[test]
     fn usage_limit_reached_with_promo_message() {
-        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).expect("valid timestamp");
         let resets_at = base + ChronoDuration::seconds(30);
         with_now_override(base, move || {
             let expected_time = format_retry_timestamp(&resets_at);

--- a/codex-rs/core/src/git_info.rs
+++ b/codex-rs/core/src/git_info.rs
@@ -759,7 +759,7 @@ mod tests {
         let repo_path = create_test_git_repo(&temp_dir).await;
 
         // Make three distinct commits with small delays to ensure ordering by timestamp.
-        fs::write(repo_path.join("file.txt"), "one").unwrap();
+        fs::write(repo_path.join("file.txt"), "one").expect("write file.txt one");
         Command::new("git")
             .args(["add", "file.txt"])
             .current_dir(&repo_path)
@@ -775,7 +775,7 @@ mod tests {
 
         sleep(Duration::from_millis(1100)).await;
 
-        fs::write(repo_path.join("file.txt"), "two").unwrap();
+        fs::write(repo_path.join("file.txt"), "two").expect("write file.txt two");
         Command::new("git")
             .args(["add", "file.txt"])
             .current_dir(&repo_path)
@@ -791,7 +791,7 @@ mod tests {
 
         sleep(Duration::from_millis(1100)).await;
 
-        fs::write(repo_path.join("file.txt"), "three").unwrap();
+        fs::write(repo_path.join("file.txt"), "three").expect("write file.txt three");
         Command::new("git")
             .args(["add", "file.txt"])
             .current_dir(&repo_path)
@@ -822,13 +822,13 @@ mod tests {
         let remote_path = temp_dir.path().join("remote.git");
 
         Command::new("git")
-            .args(["init", "--bare", remote_path.to_str().unwrap()])
+            .args(["init", "--bare", remote_path.to_str().expect("remote path")])
             .output()
             .await
             .expect("Failed to init bare remote");
 
         Command::new("git")
-            .args(["remote", "add", "origin", remote_path.to_str().unwrap()])
+            .args(["remote", "add", "origin", remote_path.to_str().expect("remote path")])
             .current_dir(&repo_path)
             .output()
             .await
@@ -840,7 +840,7 @@ mod tests {
             .output()
             .await
             .expect("Failed to get branch");
-        let branch = String::from_utf8(output.stdout).unwrap().trim().to_string();
+        let branch = String::from_utf8(output.stdout).expect("branch utf8").trim().to_string();
 
         Command::new("git")
             .args(["push", "-u", "origin", &branch])
@@ -870,13 +870,13 @@ mod tests {
 
         // Should have commit hash
         assert!(git_info.commit_hash.is_some());
-        let commit_hash = git_info.commit_hash.unwrap();
+        let commit_hash = git_info.commit_hash.expect("commit hash");
         assert_eq!(commit_hash.len(), 40); // SHA-1 hash should be 40 characters
         assert!(commit_hash.chars().all(|c| c.is_ascii_hexdigit()));
 
         // Should have branch (likely "main" or "master")
         assert!(git_info.branch.is_some());
-        let branch = git_info.branch.unwrap();
+        let branch = git_info.branch.expect("branch");
         assert!(branch == "main" || branch == "master");
 
         // Repository URL might be None for local repos without remote
@@ -913,10 +913,7 @@ mod tests {
             .expect("Failed to read remote url");
         // Some dev environments rewrite remotes (e.g., force SSH), so compare against
         // whatever URL Git reports instead of a fixed placeholder.
-        let expected_remote = String::from_utf8(remote_url_output.stdout)
-            .unwrap()
-            .trim()
-            .to_string();
+        let expected_remote = String::from_utf8(remote_url_output.stdout).expect("remote url utf8").trim().to_string();
 
         // Should have repository URL
         assert_eq!(git_info.repository_url, Some(expected_remote));
@@ -934,7 +931,7 @@ mod tests {
             .output()
             .await
             .expect("Failed to get HEAD");
-        let commit_hash = String::from_utf8(output.stdout).unwrap().trim().to_string();
+        let commit_hash = String::from_utf8(output.stdout).expect("commit hash utf8").trim().to_string();
 
         // Checkout the commit directly (detached HEAD)
         Command::new("git")
@@ -1017,10 +1014,7 @@ mod tests {
             .output()
             .await
             .expect("Failed to rev-parse remote");
-        let remote_sha = String::from_utf8(remote_sha.stdout)
-            .unwrap()
-            .trim()
-            .to_string();
+        let remote_sha = String::from_utf8(remote_sha.stdout).expect("remote sha utf8").trim().to_string();
 
         let state = git_diff_to_remote(&repo_path)
             .await
@@ -1035,8 +1029,8 @@ mod tests {
         let (repo_path, branch) = create_test_git_repo_with_remote(&temp_dir).await;
 
         let tracked = repo_path.join("test.txt");
-        fs::write(&tracked, "modified").unwrap();
-        fs::write(repo_path.join("untracked.txt"), "new").unwrap();
+        fs::write(&tracked, "modified").expect("write tracked");
+        fs::write(repo_path.join("untracked.txt"), "new").expect("write untracked");
 
         let remote_sha = Command::new("git")
             .args(["rev-parse", &format!("origin/{branch}")])
@@ -1044,10 +1038,7 @@ mod tests {
             .output()
             .await
             .expect("Failed to rev-parse remote");
-        let remote_sha = String::from_utf8(remote_sha.stdout)
-            .unwrap()
-            .trim()
-            .to_string();
+        let remote_sha = String::from_utf8(remote_sha.stdout).expect("remote sha utf8").trim().to_string();
 
         let state = git_diff_to_remote(&repo_path)
             .await
@@ -1088,10 +1079,7 @@ mod tests {
             .output()
             .await
             .expect("Failed to rev-parse remote");
-        let remote_sha = String::from_utf8(remote_sha.stdout)
-            .unwrap()
-            .trim()
-            .to_string();
+        let remote_sha = String::from_utf8(remote_sha.stdout).expect("remote sha utf8").trim().to_string();
 
         let state = git_diff_to_remote(&repo_path)
             .await
@@ -1109,14 +1097,14 @@ mod tests {
     async fn resolve_root_git_project_for_trust_regular_repo_returns_repo_root() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let repo_path = create_test_git_repo(&temp_dir).await;
-        let expected = std::fs::canonicalize(&repo_path).unwrap();
+        let expected = std::fs::canonicalize(&repo_path).expect("canonicalize repo");
 
         assert_eq!(
             resolve_root_git_project_for_trust(&repo_path),
             Some(expected.clone())
         );
         let nested = repo_path.join("sub/dir");
-        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::create_dir_all(&nested).expect("create nested dir");
         assert_eq!(resolve_root_git_project_for_trust(&nested), Some(expected));
     }
 
@@ -1131,7 +1119,7 @@ mod tests {
             .args([
                 "worktree",
                 "add",
-                wt_root.to_str().unwrap(),
+                wt_root.to_str().expect("worktree root str"),
                 "-b",
                 "feature/x",
             ])
@@ -1144,7 +1132,7 @@ mod tests {
             .and_then(|p| std::fs::canonicalize(p).ok());
         assert_eq!(got, expected);
         let nested = wt_root.join("nested/sub");
-        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::create_dir_all(&nested).expect("create nested dir");
         let got_nested =
             resolve_root_git_project_for_trust(&nested).and_then(|p| std::fs::canonicalize(p).ok());
         assert_eq!(got_nested, expected);
@@ -1154,7 +1142,7 @@ mod tests {
     fn resolve_root_git_project_for_trust_non_worktrees_gitdir_returns_none() {
         let tmp = TempDir::new().expect("tempdir");
         let proj = tmp.path().join("proj");
-        std::fs::create_dir_all(proj.join("nested")).unwrap();
+        std::fs::create_dir_all(proj.join("nested")).expect("create nested proj");
 
         // `.git` is a file but does not point to a worktrees path
         std::fs::write(
@@ -1164,7 +1152,7 @@ mod tests {
                 tmp.path().join("some/other/location").display()
             ),
         )
-        .unwrap();
+        .expect("write .git marker");
 
         assert!(resolve_root_git_project_for_trust(&proj).is_none());
         assert!(resolve_root_git_project_for_trust(&proj.join("nested")).is_none());
@@ -1181,12 +1169,9 @@ mod tests {
             .output()
             .await
             .expect("Failed to rev-parse remote");
-        let remote_sha = String::from_utf8(remote_sha.stdout)
-            .unwrap()
-            .trim()
-            .to_string();
+        let remote_sha = String::from_utf8(remote_sha.stdout).expect("remote sha utf8").trim().to_string();
 
-        fs::write(repo_path.join("test.txt"), "updated").unwrap();
+        fs::write(repo_path.join("test.txt"), "updated").expect("write test.txt");
         Command::new("git")
             .args(["add", "test.txt"])
             .current_dir(&repo_path)
@@ -1238,8 +1223,8 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("Should parse JSON");
 
         // Fields with None values should be omitted due to skip_serializing_if
-        assert!(!parsed.as_object().unwrap().contains_key("commit_hash"));
-        assert!(!parsed.as_object().unwrap().contains_key("branch"));
-        assert!(!parsed.as_object().unwrap().contains_key("repository_url"));
+        assert!(!parsed.as_object().expect("parse as object").contains_key("commit_hash"));
+        assert!(!parsed.as_object().expect("parse as object").contains_key("branch"));
+        assert!(!parsed.as_object().expect("parse as object").contains_key("repository_url"));
     }
 }

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -357,7 +357,7 @@ base_url = "http://localhost:11434/v1"
             supports_websockets: false,
         };
 
-        let provider: ModelProviderInfo = toml::from_str(azure_provider_toml).unwrap();
+        let provider: ModelProviderInfo = toml::from_str(azure_provider_toml).expect("parse azure toml");
         assert_eq!(expected_provider, provider);
     }
 
@@ -388,7 +388,7 @@ query_params = { api-version = "2025-04-01-preview" }
             supports_websockets: false,
         };
 
-        let provider: ModelProviderInfo = toml::from_str(azure_provider_toml).unwrap();
+        let provider: ModelProviderInfo = toml::from_str(azure_provider_toml).expect("parse azure toml");
         assert_eq!(expected_provider, provider);
     }
 
@@ -422,7 +422,7 @@ env_http_headers = { "X-Example-Env-Header" = "EXAMPLE_ENV_VAR" }
             supports_websockets: false,
         };
 
-        let provider: ModelProviderInfo = toml::from_str(azure_provider_toml).unwrap();
+        let provider: ModelProviderInfo = toml::from_str(azure_provider_toml).expect("parse azure toml");
         assert_eq!(expected_provider, provider);
     }
 

--- a/codex-rs/core/src/rollout/list.rs
+++ b/codex-rs/core/src/rollout/list.rs
@@ -1211,9 +1211,7 @@ async fn find_thread_path_by_id_str_in_subdir(
     if !root.exists() {
         return Ok(None);
     }
-    // This is safe because we know the values are valid.
-    #[allow(clippy::unwrap_used)]
-    let limit = NonZero::new(1).unwrap();
+    let limit = NonZero::new(1).expect("file search limit must be non-zero");
     let options = file_search::FileSearchOptions {
         limit,
         compute_indices: false,

--- a/codex-rs/core/src/rollout/session_index.rs
+++ b/codex-rs/core/src/rollout/session_index.rs
@@ -238,7 +238,7 @@ mod tests {
     fn write_index(path: &Path, lines: &[SessionIndexEntry]) -> std::io::Result<()> {
         let mut out = String::new();
         for entry in lines {
-            out.push_str(&serde_json::to_string(entry).unwrap());
+            out.push_str(&serde_json::to_string(entry).expect("serialize index entry"));
             out.push('\n');
         }
         std::fs::write(path, out)

--- a/codex-rs/core/src/rollout/tests.rs
+++ b/codex-rs/core/src/rollout/tests.rs
@@ -91,7 +91,7 @@ async fn insert_state_db_thread(
 // TODO(jif) fix
 // #[tokio::test]
 // async fn list_threads_prefers_state_db_when_available() {
-//     let temp = TempDir::new().unwrap();
+//     let temp = TempDir::new().expect("tempdir");
 //     let home = temp.path();
 //     let fs_uuid = Uuid::from_u128(101);
 //     write_session_file(
@@ -134,7 +134,7 @@ async fn insert_state_db_thread(
 
 // #[tokio::test]
 // async fn list_threads_db_excludes_archived_entries() {
-//     let temp = TempDir::new().unwrap();
+//     let temp = TempDir::new().expect("tempdir");
 //     let home = temp.path();
 //     let sessions_root = home.join("sessions/2025/01/03");
 //     let archived_root = home.join("archived_sessions");
@@ -179,7 +179,7 @@ async fn insert_state_db_thread(
 
 // #[tokio::test]
 // async fn list_threads_falls_back_to_files_when_state_db_is_unavailable() {
-//     let temp = TempDir::new().unwrap();
+//     let temp = TempDir::new().expect("tempdir");
 //     let home = temp.path();
 //     let fs_uuid = Uuid::from_u128(301);
 //     write_session_file(
@@ -217,12 +217,12 @@ async fn insert_state_db_thread(
 
 #[tokio::test]
 async fn find_thread_path_falls_back_when_db_path_is_stale() {
-    let temp = TempDir::new().unwrap();
+    let temp = TempDir::new().expect("tempdir");
     let home = temp.path();
     let uuid = Uuid::from_u128(302);
     let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
     let ts = "2025-01-03T13-00-00";
-    write_session_file(home, ts, uuid, 1, Some(SessionSource::Cli)).unwrap();
+    write_session_file(home, ts, uuid, 1, Some(SessionSource::Cli)).expect("write session file");
     let fs_rollout_path = home.join(format!("sessions/2025/01/03/rollout-{ts}-{uuid}.jsonl"));
 
     let stale_db_path = home.join(format!(
@@ -239,12 +239,12 @@ async fn find_thread_path_falls_back_when_db_path_is_stale() {
 
 #[tokio::test]
 async fn find_thread_path_repairs_missing_db_row_after_filesystem_fallback() {
-    let temp = TempDir::new().unwrap();
+    let temp = TempDir::new().expect("tempdir");
     let home = temp.path();
     let uuid = Uuid::from_u128(303);
     let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
     let ts = "2025-01-03T13-00-00";
-    write_session_file(home, ts, uuid, 1, Some(SessionSource::Cli)).unwrap();
+    write_session_file(home, ts, uuid, 1, Some(SessionSource::Cli)).expect("write session file");
     let fs_rollout_path = home.join(format!("sessions/2025/01/03/rollout-{ts}-{uuid}.jsonl"));
 
     // Create an empty state DB so lookup takes the DB-first path and then falls back to files.
@@ -318,7 +318,7 @@ fn write_session_file_with_provider(
     let format: &[FormatItem] =
         format_description!("[year]-[month]-[day]T[hour]-[minute]-[second]");
     let dt = PrimitiveDateTime::parse(ts_str, format)
-        .unwrap()
+        .expect("parse timestamp")
         .assume_utc();
     let dir = root
         .join("sessions")
@@ -341,7 +341,7 @@ fn write_session_file_with_provider(
     });
 
     if let Some(source) = source {
-        payload["source"] = serde_json::to_value(source).unwrap();
+        payload["source"] = serde_json::to_value(source).expect("serialize source");
     }
     if let Some(provider) = model_provider {
         payload["model_provider"] = serde_json::Value::String(provider.to_string());
@@ -387,7 +387,7 @@ fn write_session_file_with_delayed_user_event(
     let format: &[FormatItem] =
         format_description!("[year]-[month]-[day]T[hour]-[minute]-[second]");
     let dt = PrimitiveDateTime::parse(ts_str, format)
-        .unwrap()
+        .expect("parse timestamp")
         .assume_utc();
     let dir = root
         .join("sessions")
@@ -444,7 +444,7 @@ fn write_session_file_with_meta_payload(
     let format: &[FormatItem] =
         format_description!("[year]-[month]-[day]T[hour]-[minute]-[second]");
     let dt = PrimitiveDateTime::parse(ts_str, format)
-        .unwrap()
+        .expect("parse timestamp")
         .assume_utc();
     let dir = root
         .join("sessions")
@@ -479,7 +479,7 @@ fn write_session_file_with_meta_payload(
 
 #[tokio::test]
 async fn test_list_conversations_latest_first() {
-    let temp = TempDir::new().unwrap();
+    let temp = TempDir::new().expect("tempdir");
     let home = temp.path();
 
     // Fixed UUIDs for deterministic expectations
@@ -495,7 +495,7 @@ async fn test_list_conversations_latest_first() {
         3,
         Some(SessionSource::VSCode),
     )
-    .unwrap();
+    .expect("write session file");
     write_session_file(
         home,
         "2025-01-02T12-00-00",
@@ -503,7 +503,7 @@ async fn test_list_conversations_latest_first() {
         3,
         Some(SessionSource::VSCode),
     )
-    .unwrap();
+    .expect("write session file");
     write_session_file(
         home,
         "2025-01-03T12-00-00",
@@ -511,7 +511,7 @@ async fn test_list_conversations_latest_first() {
         3,
         Some(SessionSource::VSCode),
     )
-    .unwrap();
+    .expect("write session file");
 
     let provider_filter = provider_vec(&[TEST_PROVIDER]);
     let page = get_threads(
@@ -524,7 +524,7 @@ async fn test_list_conversations_latest_first() {
         TEST_PROVIDER,
     )
     .await
-    .unwrap();
+    .expect("get threads");
 
     // Build expected objects
     let p1 = home
@@ -610,7 +610,7 @@ async fn test_list_conversations_latest_first() {
 
 #[tokio::test]
 async fn test_pagination_cursor() {
-    let temp = TempDir::new().unwrap();
+    let temp = TempDir::new().expect("tempdir");
     let home = temp.path();
 
     // Fixed UUIDs for deterministic expectations
@@ -628,7 +628,7 @@ async fn test_pagination_cursor() {
         1,
         Some(SessionSource::VSCode),
     )
-    .unwrap();
+    .expect("write session file");
     write_session_file(
         home,
         "2025-03-02T09-00-00",
@@ -636,7 +636,7 @@ async fn test_pagination_cursor() {
         1,
         Some(SessionSource::VSCode),
     )
-    .unwrap();
+    .expect("write session file");
     write_session_file(
         home,
         "2025-03-03T09-00-00",
@@ -644,7 +644,7 @@ async fn test_pagination_cursor() {
         1,
         Some(SessionSource::VSCode),
     )
-    .unwrap();
+    .expect("write session file");
     write_session_file(
         home,
         "2025-03-04T09-00-00",
@@ -652,7 +652,7 @@ async fn test_pagination_cursor() {
         1,
         Some(SessionSource::VSCode),
     )
-    .unwrap();
+    .expect("write session file");
     write_session_file(
         home,
         "2025-03-05T09-00-00",
@@ -660,7 +660,7 @@ async fn test_pagination_cursor() {
         1,
         Some(SessionSource::VSCode),
     )
-    .unwrap();
+    .expect("write session file");
 
     let provider_filter = provider_vec(&[TEST_PROVIDER]);
     let page1 = get_threads(
@@ -673,7 +673,7 @@ async fn test_pagination_cursor() {
         TEST_PROVIDER,
     )
     .await
-    .unwrap();
+    .expect("get threads");
     let p5 = home
         .join("sessions")
         .join("2025")
@@ -689,7 +689,7 @@ async fn test_pagination_cursor() {
     let updated_page1: Vec<Option<String>> =
         page1.items.iter().map(|i| i.updated_at.clone()).collect();
     let expected_cursor1: Cursor =
-        serde_json::from_str(&format!("\"2025-03-04T09-00-00|{u4}\"")).unwrap();
+        serde_json::from_str(&format!("\"2025-03-04T09-00-00|{u4}\"")).expect("parse cursor");
     let expected_page1 = ThreadsPage {
         items: vec![
             ThreadItem {
@@ -741,7 +741,7 @@ async fn test_pagination_cursor() {
         TEST_PROVIDER,
     )
     .await
-    .unwrap();
+    .expect("get threads");
     let p3 = home
         .join("sessions")
         .join("2025")
@@ -757,7 +757,7 @@ async fn test_pagination_cursor() {
     let updated_page2: Vec<Option<String>> =
         page2.items.iter().map(|i| i.updated_at.clone()).collect();
     let expected_cursor2: Cursor =
-        serde_json::from_str(&format!("\"2025-03-02T09-00-00|{u2}\"")).unwrap();
+        serde_json::from_str(&format!("\"2025-03-02T09-00-00|{u2}\"")).expect("parse cursor");
     let expected_page2 = ThreadsPage {
         items: vec![
             ThreadItem {
@@ -809,7 +809,7 @@ async fn test_pagination_cursor() {
         TEST_PROVIDER,
     )
     .await
-    .unwrap();
+    .expect("get threads");
     let p1 = home
         .join("sessions")
         .join("2025")
@@ -844,12 +844,12 @@ async fn test_pagination_cursor() {
 
 #[tokio::test]
 async fn test_list_threads_scans_past_head_for_user_event() {
-    let temp = TempDir::new().unwrap();
+    let temp = TempDir::new().expect("tempdir");
     let home = temp.path();
 
     let uuid = Uuid::from_u128(99);
     let ts = "2025-05-01T10-30-00";
-    write_session_file_with_delayed_user_event(home, ts, uuid, 12).unwrap();
+    write_session_file_with_delayed_user_event(home, ts, uuid, 12).expect("write session file");
 
     let provider_filter = provider_vec(&[TEST_PROVIDER]);
     let page = get_threads(
@@ -862,7 +862,7 @@ async fn test_list_threads_scans_past_head_for_user_event() {
         TEST_PROVIDER,
     )
     .await
-    .unwrap();
+    .expect("get threads");
 
     assert_eq!(page.items.len(), 1);
     assert_eq!(page.items[0].thread_id, Some(thread_id_from_uuid(uuid)));
@@ -870,12 +870,12 @@ async fn test_list_threads_scans_past_head_for_user_event() {
 
 #[tokio::test]
 async fn test_get_thread_contents() {
-    let temp = TempDir::new().unwrap();
+    let temp = TempDir::new().expect("tempdir");
     let home = temp.path();
 
     let uuid = Uuid::new_v4();
     let ts = "2025-04-01T10-30-00";
-    write_session_file(home, ts, uuid, 2, Some(SessionSource::VSCode)).unwrap();
+    write_session_file(home, ts, uuid, 2, Some(SessionSource::VSCode)).expect("write session file");
 
     let provider_filter = provider_vec(&[TEST_PROVIDER]);
     let page = get_threads(
@@ -888,10 +888,10 @@ async fn test_get_thread_contents() {
         TEST_PROVIDER,
     )
     .await
-    .unwrap();
+    .expect("get threads");
     let path = &page.items[0].path;
 
-    let content = tokio::fs::read_to_string(path).await.unwrap();
+    let content = tokio::fs::read_to_string(path).await.expect("read file");
 
     // Page equality (single item)
     let expected_path = home
@@ -951,7 +951,7 @@ async fn test_get_thread_contents() {
 
 #[tokio::test]
 async fn test_base_instructions_missing_in_meta_defaults_to_null() {
-    let temp = TempDir::new().unwrap();
+    let temp = TempDir::new().expect("tempdir");
     let home = temp.path();
 
     let ts = "2025-04-02T10-30-00";
@@ -965,7 +965,7 @@ async fn test_base_instructions_missing_in_meta_defaults_to_null() {
         "source": "vscode",
         "model_provider": "test-provider",
     });
-    write_session_file_with_meta_payload(home, ts, uuid, payload).unwrap();
+    write_session_file_with_meta_payload(home, ts, uuid, payload).expect("write session file");
 
     let provider_filter = provider_vec(&[TEST_PROVIDER]);
     let page = get_threads(
@@ -978,7 +978,7 @@ async fn test_base_instructions_missing_in_meta_defaults_to_null() {
         TEST_PROVIDER,
     )
     .await
-    .unwrap();
+    .expect("get threads");
 
     let head = read_head_for_summary(&page.items[0].path)
         .await
@@ -992,7 +992,7 @@ async fn test_base_instructions_missing_in_meta_defaults_to_null() {
 
 #[tokio::test]
 async fn test_base_instructions_present_in_meta_is_preserved() {
-    let temp = TempDir::new().unwrap();
+    let temp = TempDir::new().expect("tempdir");
     let home = temp.path();
 
     let ts = "2025-04-03T10-30-00";
@@ -1008,7 +1008,7 @@ async fn test_base_instructions_present_in_meta_is_preserved() {
         "model_provider": "test-provider",
         "base_instructions": {"text": base_text},
     });
-    write_session_file_with_meta_payload(home, ts, uuid, payload).unwrap();
+    write_session_file_with_meta_payload(home, ts, uuid, payload).expect("write session file");
 
     let provider_filter = provider_vec(&[TEST_PROVIDER]);
     let page = get_threads(
@@ -1021,7 +1021,7 @@ async fn test_base_instructions_present_in_meta_is_preserved() {
         TEST_PROVIDER,
     )
     .await
-    .unwrap();
+    .expect("get threads");
 
     let head = read_head_for_summary(&page.items[0].path)
         .await
@@ -1036,12 +1036,12 @@ async fn test_base_instructions_present_in_meta_is_preserved() {
 
 #[tokio::test]
 async fn test_created_at_sort_uses_file_mtime_for_updated_at() -> Result<()> {
-    let temp = TempDir::new().unwrap();
+    let temp = TempDir::new().expect("tempdir");
     let home = temp.path();
 
     let ts = "2025-06-01T08-00-00";
     let uuid = Uuid::from_u128(43);
-    write_session_file(home, ts, uuid, 0, Some(SessionSource::VSCode)).unwrap();
+    write_session_file(home, ts, uuid, 0, Some(SessionSource::VSCode)).expect("write session file");
 
     let created = PrimitiveDateTime::parse(
         ts,
@@ -1082,7 +1082,7 @@ async fn test_created_at_sort_uses_file_mtime_for_updated_at() -> Result<()> {
 
 #[tokio::test]
 async fn test_updated_at_uses_file_mtime() -> Result<()> {
-    let temp = TempDir::new().unwrap();
+    let temp = TempDir::new().expect("tempdir");
     let home = temp.path();
 
     let ts = "2025-06-01T08-00-00";
@@ -1172,7 +1172,7 @@ async fn test_updated_at_uses_file_mtime() -> Result<()> {
 
 #[tokio::test]
 async fn test_stable_ordering_same_second_pagination() {
-    let temp = TempDir::new().unwrap();
+    let temp = TempDir::new().expect("tempdir");
     let home = temp.path();
 
     let ts = "2025-07-01T00-00-00";
@@ -1180,9 +1180,9 @@ async fn test_stable_ordering_same_second_pagination() {
     let u2 = Uuid::from_u128(2);
     let u3 = Uuid::from_u128(3);
 
-    write_session_file(home, ts, u1, 0, Some(SessionSource::VSCode)).unwrap();
-    write_session_file(home, ts, u2, 0, Some(SessionSource::VSCode)).unwrap();
-    write_session_file(home, ts, u3, 0, Some(SessionSource::VSCode)).unwrap();
+    write_session_file(home, ts, u1, 0, Some(SessionSource::VSCode)).expect("write session file");
+    write_session_file(home, ts, u2, 0, Some(SessionSource::VSCode)).expect("write session file");
+    write_session_file(home, ts, u3, 0, Some(SessionSource::VSCode)).expect("write session file");
 
     let provider_filter = provider_vec(&[TEST_PROVIDER]);
     let page1 = get_threads(
@@ -1195,7 +1195,7 @@ async fn test_stable_ordering_same_second_pagination() {
         TEST_PROVIDER,
     )
     .await
-    .unwrap();
+    .expect("get threads");
 
     let p3 = home
         .join("sessions")
@@ -1211,7 +1211,7 @@ async fn test_stable_ordering_same_second_pagination() {
         .join(format!("rollout-2025-07-01T00-00-00-{u2}.jsonl"));
     let updated_page1: Vec<Option<String>> =
         page1.items.iter().map(|i| i.updated_at.clone()).collect();
-    let expected_cursor1: Cursor = serde_json::from_str(&format!("\"{ts}|{u2}\"")).unwrap();
+    let expected_cursor1: Cursor = serde_json::from_str(&format!("\"{ts}|{u2}\"")).expect("parse cursor");
     let expected_page1 = ThreadsPage {
         items: vec![
             ThreadItem {
@@ -1263,7 +1263,7 @@ async fn test_stable_ordering_same_second_pagination() {
         TEST_PROVIDER,
     )
     .await
-    .unwrap();
+    .expect("get threads");
     let p1 = home
         .join("sessions")
         .join("2025")
@@ -1298,7 +1298,7 @@ async fn test_stable_ordering_same_second_pagination() {
 
 #[tokio::test]
 async fn test_source_filter_excludes_non_matching_sessions() {
-    let temp = TempDir::new().unwrap();
+    let temp = TempDir::new().expect("tempdir");
     let home = temp.path();
 
     let interactive_id = Uuid::from_u128(42);
@@ -1311,7 +1311,7 @@ async fn test_source_filter_excludes_non_matching_sessions() {
         2,
         Some(SessionSource::Cli),
     )
-    .unwrap();
+    .expect("write session file");
     write_session_file(
         home,
         "2025-08-01T10-00-00",
@@ -1319,7 +1319,7 @@ async fn test_source_filter_excludes_non_matching_sessions() {
         2,
         Some(SessionSource::Exec),
     )
-    .unwrap();
+    .expect("write session file");
 
     let provider_filter = provider_vec(&[TEST_PROVIDER]);
     let interactive_only = get_threads(
@@ -1332,7 +1332,7 @@ async fn test_source_filter_excludes_non_matching_sessions() {
         TEST_PROVIDER,
     )
     .await
-    .unwrap();
+    .expect("get threads");
     let paths: Vec<_> = interactive_only
         .items
         .iter()
@@ -1354,7 +1354,7 @@ async fn test_source_filter_excludes_non_matching_sessions() {
         TEST_PROVIDER,
     )
     .await
-    .unwrap();
+    .expect("get threads");
     let all_paths: Vec<_> = all_sessions
         .items
         .into_iter()
@@ -1371,7 +1371,7 @@ async fn test_source_filter_excludes_non_matching_sessions() {
 
 #[tokio::test]
 async fn test_model_provider_filter_selects_only_matching_sessions() -> Result<()> {
-    let temp = TempDir::new().unwrap();
+    let temp = TempDir::new().expect("tempdir");
     let home = temp.path();
 
     let openai_id = Uuid::from_u128(1);

--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -201,9 +201,9 @@ mod tests {
     fn test_writable_roots_constraint() {
         // Use a temporary directory as our workspace to avoid touching
         // the real current working directory.
-        let tmp = TempDir::new().unwrap();
+        let tmp = TempDir::new().expect("tempdir");
         let cwd = tmp.path().to_path_buf();
-        let parent = cwd.parent().unwrap().to_path_buf();
+        let parent = cwd.parent().expect("parent").to_path_buf();
 
         // Helper to build a single‑entry patch that adds a file at `p`.
         let make_add_change = |p: PathBuf| ApplyPatchAction::new_add_for_test(&p, "".to_string());
@@ -236,7 +236,7 @@ mod tests {
         // With the parent dir explicitly added as a writable root, the
         // outside write should be permitted.
         let policy_with_parent = SandboxPolicy::WorkspaceWrite {
-            writable_roots: vec![AbsolutePathBuf::try_from(parent).unwrap()],
+            writable_roots: vec![AbsolutePathBuf::try_from(parent).expect("absolute path")],
             read_only_access: Default::default(),
             network_access: false,
             exclude_tmpdir_env_var: true,
@@ -251,7 +251,7 @@ mod tests {
 
     #[test]
     fn external_sandbox_auto_approves_in_on_request() {
-        let tmp = TempDir::new().unwrap();
+        let tmp = TempDir::new().expect("tempdir");
         let cwd = tmp.path().to_path_buf();
         let add_inside = ApplyPatchAction::new_add_for_test(&cwd.join("inner.txt"), "".to_string());
 
@@ -276,9 +276,9 @@ mod tests {
 
     #[test]
     fn reject_with_all_flags_false_matches_on_request_for_out_of_root_patch() {
-        let tmp = TempDir::new().unwrap();
+        let tmp = TempDir::new().expect("tempdir");
         let cwd = tmp.path().to_path_buf();
-        let parent = cwd.parent().unwrap().to_path_buf();
+        let parent = cwd.parent().expect("parent").to_path_buf();
         let add_outside =
             ApplyPatchAction::new_add_for_test(&parent.join("outside.txt"), "".to_string());
         let policy_workspace_only = SandboxPolicy::WorkspaceWrite {
@@ -317,9 +317,9 @@ mod tests {
 
     #[test]
     fn reject_sandbox_approval_rejects_out_of_root_patch() {
-        let tmp = TempDir::new().unwrap();
+        let tmp = TempDir::new().expect("tempdir");
         let cwd = tmp.path().to_path_buf();
-        let parent = cwd.parent().unwrap().to_path_buf();
+        let parent = cwd.parent().expect("parent").to_path_buf();
         let add_outside =
             ApplyPatchAction::new_add_for_test(&parent.join("outside.txt"), "".to_string());
         let policy_workspace_only = SandboxPolicy::WorkspaceWrite {

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -349,7 +349,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "macos")]
     fn detects_zsh() {
-        let zsh_shell = get_shell(ShellType::Zsh, None).unwrap();
+        let zsh_shell = get_shell(ShellType::Zsh, None).expect("get zsh shell");
 
         let shell_path = zsh_shell.shell_path;
 
@@ -368,7 +368,7 @@ mod tests {
 
     #[test]
     fn detects_bash() {
-        let bash_shell = get_shell(ShellType::Bash, None).unwrap();
+        let bash_shell = get_shell(ShellType::Bash, None).expect("get bash shell");
         let shell_path = bash_shell.shell_path;
 
         assert!(
@@ -379,7 +379,7 @@ mod tests {
 
     #[test]
     fn detects_sh() {
-        let sh_shell = get_shell(ShellType::Sh, None).unwrap();
+        let sh_shell = get_shell(ShellType::Sh, None).expect("get sh shell");
         let shell_path = sh_shell.shell_path;
         assert!(
             shell_path.file_name().and_then(|name| name.to_str()) == Some("sh"),
@@ -412,7 +412,7 @@ mod tests {
             let output = Command::new(args[0].clone())
                 .args(&args[1..])
                 .output()
-                .unwrap();
+                .expect("run shell test");
             assert!(output.status.success());
             assert!(String::from_utf8_lossy(&output.stdout).contains("Works"));
             true
@@ -472,7 +472,7 @@ mod tests {
             .arg("-c")
             .arg("echo $SHELL")
             .output()
-            .unwrap();
+            .expect("get current shell");
 
         let shell_path = String::from_utf8_lossy(&shell.stdout).trim().to_string();
         if shell_path.ends_with("/zsh") {
@@ -505,7 +505,7 @@ mod tests {
             return;
         }
 
-        let powershell_shell = get_shell(ShellType::PowerShell, None).unwrap();
+        let powershell_shell = get_shell(ShellType::PowerShell, None).expect("get powershell");
         let shell_path = powershell_shell.shell_path;
 
         assert!(shell_path.ends_with("pwsh.exe") || shell_path.ends_with("powershell.exe"));

--- a/codex-rs/core/src/skills/loader.rs
+++ b/codex-rs/core/src/skills/loader.rs
@@ -880,7 +880,7 @@ mod tests {
             })
             .expect("serialize config"),
         )
-        .unwrap();
+        .expect("build config");
 
         let harness_overrides = ConfigOverrides {
             cwd: Some(cwd),
@@ -903,7 +903,7 @@ mod tests {
     fn mark_as_git_repo(dir: &Path) {
         // Config/project-root discovery only checks for the presence of `.git` (file or dir),
         // so we can avoid shelling out to `git init` in tests.
-        fs::write(dir.join(".git"), "gitdir: fake\n").unwrap();
+        fs::write(dir.join(".git"), "gitdir: fake\n").expect("write .git marker");
     }
 
     fn normalized(path: &Path) -> PathBuf {
@@ -1095,13 +1095,13 @@ mod tests {
 
     fn write_skill_at(root: &Path, dir: &str, name: &str, description: &str) -> PathBuf {
         let skill_dir = root.join(dir);
-        fs::create_dir_all(&skill_dir).unwrap();
+        fs::create_dir_all(&skill_dir).expect("create skill dir");
         let indented_description = description.replace('\n', "\n  ");
         let content = format!(
             "---\nname: {name}\ndescription: |-\n  {indented_description}\n---\n\n# Body\n"
         );
         let path = skill_dir.join(SKILLS_FILENAME);
-        fs::write(&path, content).unwrap();
+        fs::write(&path, content).expect("write skill file");
         path
     }
 
@@ -1110,9 +1110,9 @@ mod tests {
             .join(SKILLS_METADATA_DIR)
             .join(SKILLS_METADATA_FILENAME);
         if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).unwrap();
+            fs::create_dir_all(parent).expect("create metadata dir");
         }
-        fs::write(&path, contents).unwrap();
+        fs::write(&path, contents).expect("write skill metadata");
         path
     }
 
@@ -1773,12 +1773,12 @@ permissions:
 
     #[cfg(unix)]
     fn symlink_dir(target: &Path, link: &Path) {
-        std::os::unix::fs::symlink(target, link).unwrap();
+        std::os::unix::fs::symlink(target, link).expect("create symlink");
     }
 
     #[cfg(unix)]
     fn symlink_file(target: &Path, link: &Path) {
-        std::os::unix::fs::symlink(target, link).unwrap();
+        std::os::unix::fs::symlink(target, link).expect("create symlink");
     }
 
     #[tokio::test]
@@ -1789,7 +1789,7 @@ permissions:
 
         let shared_skill_path = write_skill_at(shared.path(), "demo", "linked-skill", "from link");
 
-        fs::create_dir_all(codex_home.path().join("skills")).unwrap();
+        fs::create_dir_all(codex_home.path().join("skills")).expect("create skills dir");
         symlink_dir(shared.path(), &codex_home.path().join("skills/shared"));
 
         let cfg = make_config(&codex_home).await;
@@ -1827,7 +1827,7 @@ permissions:
             write_skill_at(shared.path(), "demo", "linked-file-skill", "from link");
 
         let skill_dir = codex_home.path().join("skills/demo");
-        fs::create_dir_all(&skill_dir).unwrap();
+        fs::create_dir_all(&skill_dir).expect("create skill dir");
         symlink_file(&shared_skill_path, &skill_dir.join(SKILLS_FILENAME));
 
         let cfg = make_config(&codex_home).await;
@@ -1849,7 +1849,7 @@ permissions:
         // Create a cycle:
         //   $CODEX_HOME/skills/cycle/loop -> $CODEX_HOME/skills/cycle
         let cycle_dir = codex_home.path().join("skills/cycle");
-        fs::create_dir_all(&cycle_dir).unwrap();
+        fs::create_dir_all(&cycle_dir).expect("create cycle dir");
         symlink_dir(&cycle_dir, &cycle_dir.join("loop"));
 
         let skill_path = write_skill_at(&cycle_dir, "demo", "cycle-skill", "still loads");
@@ -1887,7 +1887,7 @@ permissions:
 
         let shared_skill_path =
             write_skill_at(shared.path(), "demo", "admin-linked-skill", "from link");
-        fs::create_dir_all(admin_root.path()).unwrap();
+        fs::create_dir_all(admin_root.path()).expect("create admin root");
         symlink_dir(shared.path(), &admin_root.path().join("shared"));
 
         let outcome = load_skills_from_roots([SkillRoot {
@@ -1931,7 +1931,7 @@ permissions:
             .path()
             .join(REPO_ROOT_CONFIG_DIR_NAME)
             .join(SKILLS_DIR_NAME);
-        fs::create_dir_all(&repo_skills_root).unwrap();
+        fs::create_dir_all(&repo_skills_root).expect("create repo skills root");
         symlink_dir(shared.path(), &repo_skills_root.join("shared"));
 
         let cfg = make_config_for_cwd(&codex_home, repo_dir.path().to_path_buf()).await;
@@ -1968,7 +1968,7 @@ permissions:
         write_skill_at(shared.path(), "demo", "system-linked-skill", "from link");
 
         let system_root = codex_home.path().join("skills/.system");
-        fs::create_dir_all(&system_root).unwrap();
+        fs::create_dir_all(&system_root).expect("create system root");
         symlink_dir(shared.path(), &system_root.join("shared"));
 
         let outcome = load_skills_from_roots([SkillRoot {
@@ -2061,10 +2061,10 @@ permissions:
     async fn loads_short_description_from_metadata() {
         let codex_home = tempfile::tempdir().expect("tempdir");
         let skill_dir = codex_home.path().join("skills/demo");
-        fs::create_dir_all(&skill_dir).unwrap();
+        fs::create_dir_all(&skill_dir).expect("create skill dir");
         let contents = "---\nname: demo-skill\ndescription: long description\nmetadata:\n  short-description: short summary\n---\n\n# Body\n";
         let skill_path = skill_dir.join(SKILLS_FILENAME);
-        fs::write(&skill_path, contents).unwrap();
+        fs::write(&skill_path, contents).expect("write short desc skill");
 
         let cfg = make_config(&codex_home).await;
         let outcome = load_skills_for_test(&cfg);
@@ -2094,12 +2094,12 @@ permissions:
     async fn enforces_short_description_length_limits() {
         let codex_home = tempfile::tempdir().expect("tempdir");
         let skill_dir = codex_home.path().join("skills/demo");
-        fs::create_dir_all(&skill_dir).unwrap();
+        fs::create_dir_all(&skill_dir).expect("create skill dir");
         let too_long = "x".repeat(MAX_SHORT_DESCRIPTION_LEN + 1);
         let contents = format!(
             "---\nname: demo-skill\ndescription: long description\nmetadata:\n  short-description: {too_long}\n---\n\n# Body\n"
         );
-        fs::write(skill_dir.join(SKILLS_FILENAME), contents).unwrap();
+        fs::write(skill_dir.join(SKILLS_FILENAME), contents).expect("write SKILL.md");
 
         let cfg = make_config(&codex_home).await;
         let outcome = load_skills_for_test(&cfg);
@@ -2118,17 +2118,17 @@ permissions:
     async fn skips_hidden_and_invalid() {
         let codex_home = tempfile::tempdir().expect("tempdir");
         let hidden_dir = codex_home.path().join("skills/.hidden");
-        fs::create_dir_all(&hidden_dir).unwrap();
+        fs::create_dir_all(&hidden_dir).expect("create hidden dir");
         fs::write(
             hidden_dir.join(SKILLS_FILENAME),
             "---\nname: hidden\ndescription: hidden\n---\n",
         )
-        .unwrap();
+        .expect("write hidden skill file");
 
         // Invalid because missing closing frontmatter.
         let invalid_dir = codex_home.path().join("skills/invalid");
-        fs::create_dir_all(&invalid_dir).unwrap();
-        fs::write(invalid_dir.join(SKILLS_FILENAME), "---\nname: bad").unwrap();
+        fs::create_dir_all(&invalid_dir).expect("create invalid dir");
+        fs::write(invalid_dir.join(SKILLS_FILENAME), "---\nname: bad").expect("write invalid skill");
 
         let cfg = make_config(&codex_home).await;
         let outcome = load_skills_for_test(&cfg);
@@ -2248,7 +2248,7 @@ permissions:
         mark_as_git_repo(repo_dir.path());
 
         let nested_dir = repo_dir.path().join("nested/inner");
-        fs::create_dir_all(&nested_dir).unwrap();
+        fs::create_dir_all(&nested_dir).expect("create nested dir");
 
         let root_skill_path = write_skill_at(
             &repo_dir
@@ -2451,7 +2451,7 @@ permissions:
         mark_as_git_repo(repo_dir.path());
 
         let nested_dir = repo_dir.path().join("nested/inner");
-        fs::create_dir_all(&nested_dir).unwrap();
+        fs::create_dir_all(&nested_dir).expect("create nested dir");
 
         let root_skill_path = write_skill_at(
             &repo_dir
@@ -2527,7 +2527,7 @@ permissions:
         let codex_home = tempfile::tempdir().expect("tempdir");
         let outer_dir = tempfile::tempdir().expect("tempdir");
         let repo_dir = outer_dir.path().join("repo");
-        fs::create_dir_all(&repo_dir).unwrap();
+        fs::create_dir_all(&repo_dir).expect("create repo dir");
 
         let _skill_path = write_skill_at(
             &outer_dir
@@ -2567,7 +2567,7 @@ permissions:
             "from repo",
         );
         let file_path = repo_dir.path().join("some-file.txt");
-        fs::write(&file_path, "contents").unwrap();
+        fs::write(&file_path, "contents").expect("write file path");
 
         let cfg = make_config_for_cwd(&codex_home, file_path).await;
 
@@ -2599,7 +2599,7 @@ permissions:
         let codex_home = tempfile::tempdir().expect("tempdir");
         let outer_dir = tempfile::tempdir().expect("tempdir");
         let nested_dir = outer_dir.path().join("nested/inner");
-        fs::create_dir_all(&nested_dir).unwrap();
+        fs::create_dir_all(&nested_dir).expect("create nested dir");
 
         write_skill_at(
             &outer_dir

--- a/codex-rs/core/src/skills/manager.rs
+++ b/codex-rs/core/src/skills/manager.rs
@@ -239,9 +239,9 @@ mod tests {
 
     fn write_user_skill(codex_home: &TempDir, dir: &str, name: &str, description: &str) {
         let skill_dir = codex_home.path().join("skills").join(dir);
-        fs::create_dir_all(&skill_dir).unwrap();
+        fs::create_dir_all(&skill_dir).expect("create skill dir");
         let content = format!("---\nname: {name}\ndescription: {description}\n---\n\n# Body\n");
-        fs::write(skill_dir.join("SKILL.md"), content).unwrap();
+        fs::write(skill_dir.join("SKILL.md"), content).expect("write SKILL.md");
     }
 
     #[tokio::test]

--- a/codex-rs/core/src/tasks/ghost_snapshot.rs
+++ b/codex-rs/core/src/tasks/ghost_snapshot.rs
@@ -262,7 +262,7 @@ mod tests {
             ignored_untracked_files: Vec::new(),
         };
 
-        let message = format_large_untracked_warning(Some(200), &report).unwrap();
+        let message = format_large_untracked_warning(Some(200), &report).expect("warning should be Some");
         assert!(message.contains(">= 200 files"));
     }
 

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -699,8 +699,8 @@ mod tests {
             RolloutItem::ResponseItem(items[2].clone()),
         ];
         assert_eq!(
-            serde_json::to_value(&got_items).unwrap(),
-            serde_json::to_value(&expected_items).unwrap()
+            serde_json::to_value(&got_items).expect("serialize got_items"),
+            serde_json::to_value(&expected_items).expect("serialize expected_items")
         );
 
         let initial2: Vec<RolloutItem> = items
@@ -738,8 +738,8 @@ mod tests {
         ];
 
         assert_eq!(
-            serde_json::to_value(&got_items).unwrap(),
-            serde_json::to_value(&expected).unwrap()
+            serde_json::to_value(&got_items).expect("serialize got_items"),
+            serde_json::to_value(&expected).expect("serialize expected")
         );
     }
 }

--- a/codex-rs/core/src/token_data.rs
+++ b/codex-rs/core/src/token_data.rs
@@ -202,8 +202,8 @@ mod tests {
             base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
         }
 
-        let header_b64 = b64url_no_pad(&serde_json::to_vec(&header).unwrap());
-        let payload_b64 = b64url_no_pad(&serde_json::to_vec(&payload).unwrap());
+        let header_b64 = b64url_no_pad(&serde_json::to_vec(&header).expect("serialize test header"));
+        let payload_b64 = b64url_no_pad(&serde_json::to_vec(&payload).expect("serialize test payload"));
         let signature_b64 = b64url_no_pad(b"sig");
         let fake_jwt = format!("{header_b64}.{payload_b64}.{signature_b64}");
 
@@ -234,8 +234,8 @@ mod tests {
             base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
         }
 
-        let header_b64 = b64url_no_pad(&serde_json::to_vec(&header).unwrap());
-        let payload_b64 = b64url_no_pad(&serde_json::to_vec(&payload).unwrap());
+        let header_b64 = b64url_no_pad(&serde_json::to_vec(&header).expect("serialize test header"));
+        let payload_b64 = b64url_no_pad(&serde_json::to_vec(&payload).expect("serialize test payload"));
         let signature_b64 = b64url_no_pad(b"sig");
         let fake_jwt = format!("{header_b64}.{payload_b64}.{signature_b64}");
 
@@ -261,8 +261,8 @@ mod tests {
             base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
         }
 
-        let header_b64 = b64url_no_pad(&serde_json::to_vec(&header).unwrap());
-        let payload_b64 = b64url_no_pad(&serde_json::to_vec(&payload).unwrap());
+        let header_b64 = b64url_no_pad(&serde_json::to_vec(&header).expect("serialize test header"));
+        let payload_b64 = b64url_no_pad(&serde_json::to_vec(&payload).expect("serialize test payload"));
         let signature_b64 = b64url_no_pad(b"sig");
         let fake_jwt = format!("{header_b64}.{payload_b64}.{signature_b64}");
 

--- a/codex-rs/core/src/tools/handlers/grep_files.rs
+++ b/codex-rs/core/src/tools/handlers/grep_files.rs
@@ -203,9 +203,9 @@ mod tests {
         }
         let temp = tempdir().expect("create temp dir");
         let dir = temp.path();
-        std::fs::write(dir.join("match_one.txt"), "alpha beta gamma").unwrap();
-        std::fs::write(dir.join("match_two.txt"), "alpha delta").unwrap();
-        std::fs::write(dir.join("other.txt"), "omega").unwrap();
+        std::fs::write(dir.join("match_one.txt"), "alpha beta gamma").expect("write file");
+        std::fs::write(dir.join("match_two.txt"), "alpha delta").expect("write file");
+        std::fs::write(dir.join("other.txt"), "omega").expect("write file");
 
         let results = run_rg_search("alpha", None, dir, 10, dir).await?;
         assert_eq!(results.len(), 2);
@@ -221,8 +221,8 @@ mod tests {
         }
         let temp = tempdir().expect("create temp dir");
         let dir = temp.path();
-        std::fs::write(dir.join("match_one.rs"), "alpha beta gamma").unwrap();
-        std::fs::write(dir.join("match_two.txt"), "alpha delta").unwrap();
+        std::fs::write(dir.join("match_one.rs"), "alpha beta gamma").expect("write file");
+        std::fs::write(dir.join("match_two.txt"), "alpha delta").expect("write file");
 
         let results = run_rg_search("alpha", Some("*.rs"), dir, 10, dir).await?;
         assert_eq!(results.len(), 1);
@@ -237,9 +237,9 @@ mod tests {
         }
         let temp = tempdir().expect("create temp dir");
         let dir = temp.path();
-        std::fs::write(dir.join("one.txt"), "alpha one").unwrap();
-        std::fs::write(dir.join("two.txt"), "alpha two").unwrap();
-        std::fs::write(dir.join("three.txt"), "alpha three").unwrap();
+        std::fs::write(dir.join("one.txt"), "alpha one").expect("write file");
+        std::fs::write(dir.join("two.txt"), "alpha two").expect("write file");
+        std::fs::write(dir.join("three.txt"), "alpha three").expect("write file");
 
         let results = run_rg_search("alpha", None, dir, 2, dir).await?;
         assert_eq!(results.len(), 2);
@@ -253,7 +253,7 @@ mod tests {
         }
         let temp = tempdir().expect("create temp dir");
         let dir = temp.path();
-        std::fs::write(dir.join("one.txt"), "omega").unwrap();
+        std::fs::write(dir.join("one.txt"), "omega").expect("write file");
 
         let results = run_rg_search("alpha", None, dir, 5, dir).await?;
         assert!(results.is_empty());

--- a/codex-rs/core/src/tools/handlers/mcp_resource.rs
+++ b/codex-rs/core/src/tools/handlers/mcp_resource.rs
@@ -744,7 +744,7 @@ mod tests {
             .as_array()
             .expect("resources array")
             .iter()
-            .map(|entry| entry["uri"].as_str().unwrap().to_string())
+            .map(|entry| entry["uri"].as_str().expect("uri string").to_string())
             .collect();
 
         assert_eq!(
@@ -767,12 +767,12 @@ mod tests {
     #[test]
     fn parse_arguments_handles_empty_and_json() {
         assert!(
-            parse_arguments(" \n\t").unwrap().is_none(),
+            parse_arguments(" \n\t").expect("parse empty args").is_none(),
             "expected None for empty arguments"
         );
 
         assert!(
-            parse_arguments("null").unwrap().is_none(),
+            parse_arguments("null").expect("parse null").is_none(),
             "expected None for null arguments"
         );
 

--- a/codex-rs/core/src/tools/js_repl/mod.rs
+++ b/codex-rs/core/src/tools/js_repl/mod.rs
@@ -1685,7 +1685,7 @@ mod tests {
 
     #[test]
     fn node_version_parses_v_prefix_and_suffix() {
-        let version = NodeVersion::parse("v25.1.0-nightly.2024").unwrap();
+        let version = NodeVersion::parse("v25.1.0-nightly.2024").expect("parse test version");
         assert_eq!(
             version,
             NodeVersion {

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation_tests.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation_tests.rs
@@ -62,14 +62,14 @@ fn starlark_string(value: &str) -> String {
 #[test]
 fn extract_shell_script_preserves_login_flag() {
     assert_eq!(
-        extract_shell_script(&["/bin/zsh".into(), "-lc".into(), "echo hi".into()]).unwrap(),
+        extract_shell_script(&["/bin/zsh".into(), "-lc".into(), "echo hi".into()]).expect("parse zsh login shell command"),
         ParsedShellCommand {
             script: "echo hi".to_string(),
             login: true,
         }
     );
     assert_eq!(
-        extract_shell_script(&["/bin/zsh".into(), "-c".into(), "echo hi".into()]).unwrap(),
+        extract_shell_script(&["/bin/zsh".into(), "-c".into(), "echo hi".into()]).expect("parse zsh command"),
         ParsedShellCommand {
             script: "echo hi".to_string(),
             login: false,
@@ -87,7 +87,7 @@ fn extract_shell_script_supports_wrapped_command_prefixes() {
             "-lc".into(),
             "echo hello".into()
         ])
-        .unwrap(),
+        .expect("parse env-wrapped command"),
         ParsedShellCommand {
             script: "echo hello".to_string(),
             login: true,
@@ -103,7 +103,7 @@ fn extract_shell_script_supports_wrapped_command_prefixes() {
             "-c".into(),
             "pwd".into(),
         ])
-        .unwrap(),
+        .expect("parse sandbox-exec command"),
         ParsedShellCommand {
             script: "pwd".to_string(),
             login: false,
@@ -133,14 +133,14 @@ fn extract_shell_script_rejects_unsupported_shell_invocation() {
 fn join_program_and_argv_replaces_original_argv_zero() {
     assert_eq!(
         join_program_and_argv(
-            &AbsolutePathBuf::from_absolute_path("/tmp/tool").unwrap(),
+            &AbsolutePathBuf::from_absolute_path("/tmp/tool").expect("absolute path"),
             &["./tool".into(), "--flag".into(), "value".into()],
         ),
         vec!["/tmp/tool", "--flag", "value"]
     );
     assert_eq!(
         join_program_and_argv(
-            &AbsolutePathBuf::from_absolute_path("/tmp/tool").unwrap(),
+            &AbsolutePathBuf::from_absolute_path("/tmp/tool").expect("absolute path"),
             &["./tool".into()]
         ),
         vec!["/tmp/tool"]
@@ -149,7 +149,7 @@ fn join_program_and_argv_replaces_original_argv_zero() {
 
 #[test]
 fn commands_for_intercepted_exec_policy_parses_plain_shell_wrappers() {
-    let program = AbsolutePathBuf::try_from(host_absolute_path(&["bin", "bash"])).unwrap();
+    let program = AbsolutePathBuf::try_from(host_absolute_path(&["bin", "bash"])).expect("absolute bash path");
     let candidate_commands = commands_for_intercepted_exec_policy(
         &program,
         &["not-bash".into(), "-lc".into(), "git status && pwd".into()],
@@ -178,7 +178,7 @@ fn map_exec_result_preserves_stdout_and_stderr() {
             timed_out: false,
         },
     )
-    .unwrap();
+    .expect("prepare escalated exec");
 
     assert_eq!(out.stdout.text, "out");
     assert_eq!(out.stderr.text, "err");
@@ -191,13 +191,13 @@ fn shell_request_escalation_execution_is_explicit() {
         file_system: Some(FileSystemPermissions {
             read: None,
             write: Some(vec![
-                AbsolutePathBuf::from_absolute_path("/tmp/output").unwrap(),
+                AbsolutePathBuf::from_absolute_path("/tmp/output").expect("absolute path"),
             ]),
         }),
         ..Default::default()
     };
     let sandbox_policy = SandboxPolicy::WorkspaceWrite {
-        writable_roots: vec![AbsolutePathBuf::from_absolute_path("/tmp/original/output").unwrap()],
+        writable_roots: vec![AbsolutePathBuf::from_absolute_path("/tmp/original/output").expect("absolute path")],
         read_only_access: ReadOnlyAccess::FullAccess,
         network_access: false,
         exclude_tmpdir_env_var: false,
@@ -246,9 +246,9 @@ fn shell_request_escalation_execution_is_explicit() {
 fn evaluate_intercepted_exec_policy_uses_wrapper_command_when_shell_wrapper_parsing_disabled() {
     let policy_src = r#"prefix_rule(pattern = ["npm", "publish"], decision = "prompt")"#;
     let mut parser = PolicyParser::new();
-    parser.parse("test.rules", policy_src).unwrap();
+    parser.parse("test.rules", policy_src).expect("parse policy src");
     let policy = parser.build();
-    let program = AbsolutePathBuf::try_from(host_absolute_path(&["bin", "zsh"])).unwrap();
+    let program = AbsolutePathBuf::try_from(host_absolute_path(&["bin", "zsh"])).expect("absolute zsh path");
 
     let enable_intercepted_exec_policy_shell_wrapper_parsing = false;
     let evaluation = evaluate_intercepted_exec_policy(
@@ -294,9 +294,9 @@ ultimately intercept the `npm publish` command and apply the policy rules to it.
 fn evaluate_intercepted_exec_policy_matches_inner_shell_commands_when_enabled() {
     let policy_src = r#"prefix_rule(pattern = ["npm", "publish"], decision = "prompt")"#;
     let mut parser = PolicyParser::new();
-    parser.parse("test.rules", policy_src).unwrap();
+    parser.parse("test.rules", policy_src).expect("parse policy src");
     let policy = parser.build();
-    let program = AbsolutePathBuf::try_from(host_absolute_path(&["bin", "bash"])).unwrap();
+    let program = AbsolutePathBuf::try_from(host_absolute_path(&["bin", "bash"])).expect("absolute bash path");
 
     let enable_intercepted_exec_policy_shell_wrapper_parsing = true;
     let evaluation = evaluate_intercepted_exec_policy(
@@ -338,9 +338,9 @@ host_executable(name = "git", paths = ["{git_path_literal}"])
 "#
     );
     let mut parser = PolicyParser::new();
-    parser.parse("test.rules", &policy_src).unwrap();
+    parser.parse("test.rules", &policy_src).expect("parse starlark policy");
     let policy = parser.build();
-    let program = AbsolutePathBuf::try_from(git_path).unwrap();
+    let program = AbsolutePathBuf::try_from(git_path).expect("absolute git path");
 
     let evaluation = evaluate_intercepted_exec_policy(
         &policy,
@@ -382,9 +382,9 @@ host_executable(name = "git", paths = ["{allowed_git_literal}"])
 "#
     );
     let mut parser = PolicyParser::new();
-    parser.parse("test.rules", &policy_src).unwrap();
+    parser.parse("test.rules", &policy_src).expect("parse starlark policy");
     let policy = parser.build();
-    let program = AbsolutePathBuf::try_from(other_git.clone()).unwrap();
+    let program = AbsolutePathBuf::try_from(other_git.clone()).expect("absolute other git path");
 
     let evaluation = evaluate_intercepted_exec_policy(
         &policy,
@@ -410,7 +410,7 @@ host_executable(name = "git", paths = ["{allowed_git_literal}"])
 #[cfg(target_os = "macos")]
 #[tokio::test]
 async fn prepare_escalated_exec_turn_default_preserves_macos_seatbelt_extensions() {
-    let cwd = AbsolutePathBuf::from_absolute_path(std::env::temp_dir()).unwrap();
+    let cwd = AbsolutePathBuf::from_absolute_path(std::env::temp_dir()).expect("temp dir path");
     let executor = CoreShellCommandExecutor {
         command: vec!["echo".to_string(), "ok".to_string()],
         cwd: cwd.to_path_buf(),
@@ -433,14 +433,14 @@ async fn prepare_escalated_exec_turn_default_preserves_macos_seatbelt_extensions
 
     let prepared = executor
         .prepare_escalated_exec(
-            &AbsolutePathBuf::from_absolute_path("/bin/echo").unwrap(),
+            &AbsolutePathBuf::from_absolute_path("/bin/echo").expect("echo path"),
             &["echo".to_string(), "ok".to_string()],
             &cwd,
             HashMap::new(),
             EscalationExecution::TurnDefault,
         )
         .await
-        .unwrap();
+        .expect("prepare escalated exec");
 
     assert_eq!(
         prepared.command.first().map(String::as_str),
@@ -460,7 +460,7 @@ async fn prepare_escalated_exec_turn_default_preserves_macos_seatbelt_extensions
 #[cfg(target_os = "macos")]
 #[tokio::test]
 async fn prepare_escalated_exec_permissions_preserve_macos_seatbelt_extensions() {
-    let cwd = AbsolutePathBuf::from_absolute_path(std::env::temp_dir()).unwrap();
+    let cwd = AbsolutePathBuf::from_absolute_path(std::env::temp_dir()).expect("temp dir path");
     let executor = CoreShellCommandExecutor {
         command: vec!["echo".to_string(), "ok".to_string()],
         cwd: cwd.to_path_buf(),
@@ -493,7 +493,7 @@ async fn prepare_escalated_exec_permissions_preserve_macos_seatbelt_extensions()
 
     let prepared = executor
         .prepare_escalated_exec(
-            &AbsolutePathBuf::from_absolute_path("/bin/echo").unwrap(),
+            &AbsolutePathBuf::from_absolute_path("/bin/echo").expect("echo path"),
             &["echo".to_string(), "ok".to_string()],
             &cwd,
             HashMap::new(),
@@ -507,7 +507,7 @@ async fn prepare_escalated_exec_permissions_preserve_macos_seatbelt_extensions()
             )),
         )
         .await
-        .unwrap();
+        .expect("prepare escalated exec");
 
     assert_eq!(
         prepared.command.first().map(String::as_str),

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -3280,7 +3280,7 @@ Examples of valid command strings:
             },
         })];
 
-        let responses_json = create_tools_json_for_responses_api(&tools).unwrap();
+        let responses_json = create_tools_json_for_responses_api(&tools).expect("create tools json");
         assert_eq!(
             responses_json,
             vec![json!({

--- a/codex-rs/core/src/turn_diff_tracker.rs
+++ b/codex-rs/core/src/turn_diff_tracker.rs
@@ -507,7 +507,7 @@ mod tests {
     fn accumulates_add_and_update() {
         let mut acc = TurnDiffTracker::new();
 
-        let dir = tempdir().unwrap();
+        let dir = tempdir().expect("tempdir");
         let file = dir.path().join("a.txt");
 
         // First patch: add file (baseline should be /dev/null).
@@ -520,8 +520,8 @@ mod tests {
         acc.on_patch_begin(&add_changes);
 
         // Simulate apply: create the file on disk.
-        fs::write(&file, "foo\n").unwrap();
-        let first = acc.get_unified_diff().unwrap().unwrap();
+        fs::write(&file, "foo\n").expect("write file");
+        let first = acc.get_unified_diff().expect("unified diff").expect("unified diff");
         let first = normalize_diff_for_test(&first, dir.path());
         let expected_first = {
             let mode = file_mode_for_path(&file).unwrap_or(FileMode::Regular);
@@ -550,8 +550,8 @@ index {ZERO_OID}..{right_oid}
         acc.on_patch_begin(&update_changes);
 
         // Simulate apply: append a new line.
-        fs::write(&file, "foo\nbar\n").unwrap();
-        let combined = acc.get_unified_diff().unwrap().unwrap();
+        fs::write(&file, "foo\nbar\n").expect("write file");
+        let combined = acc.get_unified_diff().expect("unified diff").expect("unified diff");
         let combined = normalize_diff_for_test(&combined, dir.path());
         let expected_combined = {
             let mode = file_mode_for_path(&file).unwrap_or(FileMode::Regular);
@@ -573,9 +573,9 @@ index {ZERO_OID}..{right_oid}
 
     #[test]
     fn accumulates_delete() {
-        let dir = tempdir().unwrap();
+        let dir = tempdir().expect("tempdir");
         let file = dir.path().join("b.txt");
-        fs::write(&file, "x\n").unwrap();
+        fs::write(&file, "x\n").expect("write b.txt");
 
         let mut acc = TurnDiffTracker::new();
         let del_changes = HashMap::from([(
@@ -588,8 +588,8 @@ index {ZERO_OID}..{right_oid}
 
         // Simulate apply: delete the file from disk.
         let baseline_mode = file_mode_for_path(&file).unwrap_or(FileMode::Regular);
-        fs::remove_file(&file).unwrap();
-        let diff = acc.get_unified_diff().unwrap().unwrap();
+        fs::remove_file(&file).expect("remove file");
+        let diff = acc.get_unified_diff().expect("get unified diff").expect("diff should be present");
         let diff = normalize_diff_for_test(&diff, dir.path());
         let expected = {
             let left_oid = git_blob_sha1_hex("x\n");
@@ -609,10 +609,10 @@ index {left_oid}..{ZERO_OID}
 
     #[test]
     fn accumulates_move_and_update() {
-        let dir = tempdir().unwrap();
+        let dir = tempdir().expect("tempdir");
         let src = dir.path().join("src.txt");
         let dest = dir.path().join("dst.txt");
-        fs::write(&src, "line\n").unwrap();
+        fs::write(&src, "line\n").expect("write src file");
 
         let mut acc = TurnDiffTracker::new();
         let mv_changes = HashMap::from([(
@@ -625,10 +625,10 @@ index {left_oid}..{ZERO_OID}
         acc.on_patch_begin(&mv_changes);
 
         // Simulate apply: move and update content.
-        fs::rename(&src, &dest).unwrap();
-        fs::write(&dest, "line2\n").unwrap();
+        fs::rename(&src, &dest).expect("rename file");
+        fs::write(&dest, "line2\n").expect("write dest file");
 
-        let out = acc.get_unified_diff().unwrap().unwrap();
+        let out = acc.get_unified_diff().expect("unified diff").expect("unified diff");
         let out = normalize_diff_for_test(&out, dir.path());
         let expected = {
             let left_oid = git_blob_sha1_hex("line\n");
@@ -649,10 +649,10 @@ index {left_oid}..{right_oid}
 
     #[test]
     fn move_without_1change_yields_no_diff() {
-        let dir = tempdir().unwrap();
+        let dir = tempdir().expect("tempdir");
         let src = dir.path().join("moved.txt");
         let dest = dir.path().join("renamed.txt");
-        fs::write(&src, "same\n").unwrap();
+        fs::write(&src, "same\n").expect("write src");
 
         let mut acc = TurnDiffTracker::new();
         let mv_changes = HashMap::from([(
@@ -665,15 +665,15 @@ index {left_oid}..{right_oid}
         acc.on_patch_begin(&mv_changes);
 
         // Simulate apply: move only, no content change.
-        fs::rename(&src, &dest).unwrap();
+        fs::rename(&src, &dest).expect("rename file");
 
-        let diff = acc.get_unified_diff().unwrap();
+        let diff = acc.get_unified_diff().expect("unified diff");
         assert_eq!(diff, None);
     }
 
     #[test]
     fn move_declared_but_file_only_appears_at_dest_is_add() {
-        let dir = tempdir().unwrap();
+        let dir = tempdir().expect("tempdir");
         let src = dir.path().join("src.txt");
         let dest = dir.path().join("dest.txt");
         let mut acc = TurnDiffTracker::new();
@@ -686,8 +686,8 @@ index {left_oid}..{right_oid}
         )]);
         acc.on_patch_begin(&mv);
         // No file existed initially; create only dest
-        fs::write(&dest, "hello\n").unwrap();
-        let diff = acc.get_unified_diff().unwrap().unwrap();
+        fs::write(&dest, "hello\n").expect("write dest");
+        let diff = acc.get_unified_diff().expect("get unified diff").expect("diff should be present");
         let diff = normalize_diff_for_test(&diff, dir.path());
         let expected = {
             let mode = file_mode_for_path(&dest).unwrap_or(FileMode::Regular);
@@ -708,11 +708,11 @@ index {ZERO_OID}..{right_oid}
 
     #[test]
     fn update_persists_across_new_baseline_for_new_file() {
-        let dir = tempdir().unwrap();
+        let dir = tempdir().expect("tempdir");
         let a = dir.path().join("a.txt");
         let b = dir.path().join("b.txt");
-        fs::write(&a, "foo\n").unwrap();
-        fs::write(&b, "z\n").unwrap();
+        fs::write(&a, "foo\n").expect("write a");
+        fs::write(&b, "z\n").expect("write b");
 
         let mut acc = TurnDiffTracker::new();
 
@@ -726,8 +726,8 @@ index {ZERO_OID}..{right_oid}
         )]);
         acc.on_patch_begin(&update_a);
         // Simulate apply: modify a.txt on disk.
-        fs::write(&a, "foo\nbar\n").unwrap();
-        let first = acc.get_unified_diff().unwrap().unwrap();
+        fs::write(&a, "foo\nbar\n").expect("write a");
+        let first = acc.get_unified_diff().expect("unified diff").expect("unified diff");
         let first = normalize_diff_for_test(&first, dir.path());
         let expected_first = {
             let left_oid = git_blob_sha1_hex("foo\n");
@@ -755,9 +755,9 @@ index {left_oid}..{right_oid}
         acc.on_patch_begin(&del_b);
         // Simulate apply: delete b.txt.
         let baseline_mode = file_mode_for_path(&b).unwrap_or(FileMode::Regular);
-        fs::remove_file(&b).unwrap();
+        fs::remove_file(&b).expect("remove b");
 
-        let combined = acc.get_unified_diff().unwrap().unwrap();
+        let combined = acc.get_unified_diff().expect("unified diff").expect("unified diff");
         let combined = normalize_diff_for_test(&combined, dir.path());
         let expected = {
             let left_oid_a = git_blob_sha1_hex("foo\n");
@@ -786,7 +786,7 @@ index {left_oid_b}..{ZERO_OID}
 
     #[test]
     fn binary_files_differ_update() {
-        let dir = tempdir().unwrap();
+        let dir = tempdir().expect("tempdir");
         let file = dir.path().join("bin.dat");
 
         // Initial non-UTF8 bytes
@@ -794,7 +794,7 @@ index {left_oid_b}..{ZERO_OID}
         // Updated non-UTF8 bytes
         let right_bytes: Vec<u8> = vec![0x01, 0x02, 0x03, 0x00];
 
-        fs::write(&file, &left_bytes).unwrap();
+        fs::write(&file, &left_bytes).expect("write left bytes");
 
         let mut acc = TurnDiffTracker::new();
         let update_changes = HashMap::from([(
@@ -807,9 +807,9 @@ index {left_oid_b}..{ZERO_OID}
         acc.on_patch_begin(&update_changes);
 
         // Apply update on disk
-        fs::write(&file, &right_bytes).unwrap();
+        fs::write(&file, &right_bytes).expect("write right bytes");
 
-        let diff = acc.get_unified_diff().unwrap().unwrap();
+        let diff = acc.get_unified_diff().expect("get unified diff").expect("diff should be present");
         let diff = normalize_diff_for_test(&diff, dir.path());
         let expected = {
             let left_oid = format!("{:x}", git_blob_sha1_hex_bytes(&left_bytes));
@@ -830,7 +830,7 @@ Binary files differ
     fn filenames_with_spaces_add_and_update() {
         let mut acc = TurnDiffTracker::new();
 
-        let dir = tempdir().unwrap();
+        let dir = tempdir().expect("tempdir");
         let file = dir.path().join("name with spaces.txt");
 
         // First patch: add file (baseline should be /dev/null).
@@ -843,8 +843,8 @@ Binary files differ
         acc.on_patch_begin(&add_changes);
 
         // Simulate apply: create the file on disk.
-        fs::write(&file, "foo\n").unwrap();
-        let first = acc.get_unified_diff().unwrap().unwrap();
+        fs::write(&file, "foo\n").expect("write file");
+        let first = acc.get_unified_diff().expect("unified diff").expect("unified diff");
         let first = normalize_diff_for_test(&first, dir.path());
         let expected_first = {
             let mode = file_mode_for_path(&file).unwrap_or(FileMode::Regular);
@@ -873,8 +873,8 @@ index {ZERO_OID}..{right_oid}
         acc.on_patch_begin(&update_changes);
 
         // Simulate apply: append a new line with a space.
-        fs::write(&file, "foo\nbar baz\n").unwrap();
-        let combined = acc.get_unified_diff().unwrap().unwrap();
+        fs::write(&file, "foo\nbar baz\n").expect("write file");
+        let combined = acc.get_unified_diff().expect("unified diff").expect("unified diff");
         let combined = normalize_diff_for_test(&combined, dir.path());
         let expected_combined = {
             let mode = file_mode_for_path(&file).unwrap_or(FileMode::Regular);

--- a/codex-rs/core/src/util.rs
+++ b/codex-rs/core/src/util.rs
@@ -148,14 +148,14 @@ mod tests {
 
     #[test]
     fn resume_command_prefers_name_over_id() {
-        let thread_id = ThreadId::from_string("123e4567-e89b-12d3-a456-426614174000").unwrap();
+        let thread_id = ThreadId::from_string("123e4567-e89b-12d3-a456-426614174000").expect("parse test thread id");
         let command = resume_command(Some("my-thread"), Some(thread_id));
         assert_eq!(command, Some("codex resume my-thread".to_string()));
     }
 
     #[test]
     fn resume_command_with_only_id() {
-        let thread_id = ThreadId::from_string("123e4567-e89b-12d3-a456-426614174000").unwrap();
+        let thread_id = ThreadId::from_string("123e4567-e89b-12d3-a456-426614174000").expect("parse test thread id");
         let command = resume_command(None, Some(thread_id));
         assert_eq!(
             command,


### PR DESCRIPTION
Rescued unpushed commits from heliosCLI-monorepo-temp directory. Contains:
- codex-rs core WIP modifications 
- worktree pointer updates
- rollout fix (may duplicate PR #130)
- sync commit

This PR has conflicts with main and requires manual resolution before merging.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>