### PR TITLE
docs(heliosCLI): publish governance baseline surfaces

### DIFF
--- a/.github/RULESET_BASELINE.md
+++ b/.github/RULESET_BASELINE.md
@@ -1,0 +1,43 @@
+# heliosCLI Ruleset Baseline
+
+This file defines the intended GitHub-side ruleset posture for `heliosCLI` until repo settings are
+verified and synced directly.
+
+## Branches
+
+- protect `main`
+- disallow force-push
+- disallow branch deletion
+- require pull requests for merge
+- require at least one approval
+- dismiss stale approvals on push
+- require review thread resolution before merge
+
+## Merge Policy
+
+- no direct fix branches to `main` without explicit `layered-pr-exception`
+- no merge when policy or CI checks are failing
+- require branch to be up to date with base before merge
+- permit stacked PRs only when each layer is independently reviewable
+
+## Minimum Required Checks
+
+These names should be verified against live GitHub check-run titles before server-side enforcement:
+
+- `policy-gate`
+- `Drift detection`
+- `Format / etc`
+- `cargo shear`
+- `Stage Gates / detect-stage`
+- `Semgrep Scan`
+- `Secret Scanning`
+- `Rust Lint`
+- `License Compliance`
+
+## Notes
+
+- `quality.yml` is currently manual-only and should not be treated as a merge blocker until it runs
+  on pull requests.
+- Helper or babysit workflows should stay outside the required-check set.
+- If a required job name changes, update this file and the corresponding GitHub branch protection in
+  the same tranche.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,122 +1,68 @@
-# heliosHarness Governance Model
+# heliosCLI Governance Model
 
 ## Purpose
 
-**heliosHarness** is a private research & planning monorepo for developing, analyzing, and organizing the heliosCLI system architecture. It does **not** contain production code - instead, it researches, prototypes, and defines how to extend other projects.
+`heliosCLI` is an active Rust CLI repo. Governance here is delivery-focused, not research-only:
 
-## Project Shelf Model
+- changes land through reviewable pull requests
+- protected branches do not accept force-pushes or direct fixes
+- CI and policy gates must be green before merge
+- stacked PRs are allowed only when each layer is independently reviewable
 
-Like `kush/` - heliosHarness serves as a **project shelf** for organizing dependencies and research.
+This file is the repo-local control surface for branch and merge discipline. It complements
+[`AGENTS.md`](./AGENTS.md), the workflow files under [`.github/workflows`](./.github/workflows), and
+the repo-local ruleset baseline at [`.github/RULESET_BASELINE.md`](./.github/RULESET_BASELINE.md).
 
-## Module Categories
+## Protected Branch Posture
 
-### 1. Clones (forked external projects)
+- Treat `main` as protected.
+- Do not force-push shared branches.
+- Do not merge with unresolved review threads or failing checks.
+- Do not use `--no-verify` as normal workflow on active lanes.
+- Use personal feature branches or worktree branches for intermediate cleanup.
 
-```
-clones/
-├── codex/          # Forked Codex CLI research
-├── goose/           # Forked Goose research
-├── cline/           # Forked Cline research
-├── aider/           # Forked Aider research
-├── opencode/         # Forked OpenCode research
-└── [other forks/]
-```
+## Active Governance Gates
 
-### 2. Extensions (plugin systems)
+The repo currently has these live governance and CI surfaces:
 
-```
-extensions/
-├── codex-plugins/      # Codex CLI extensibility
-├── harbor-plugins/      # Harbor framework plugins
-├── portage-plugins/     # Portage module system
-└── [project]-plugins/
-```
+- [`.github/workflows/policy-gate.yml`](./.github/workflows/policy-gate.yml)
+- [`.github/actions/policy-gate/action.yml`](./.github/actions/policy-gate/action.yml)
+- [`.github/workflows/rust-ci.yml`](./.github/workflows/rust-ci.yml)
+- [`.github/workflows/stage-gates.yml`](./.github/workflows/stage-gates.yml)
+- [`.github/workflows/sast-quick.yml`](./.github/workflows/sast-quick.yml)
 
-### 3. Plugins (modular extension system)
+These are the real local enforcement surfaces. This branch does not currently expose a tracked
+`.github/rulesets/` directory, so repo settings must be synchronized against the documented
+baseline rather than inferred from missing local JSON.
 
-```
-plugins/
-├── protocol/        # Plugin protocol definitions
-├── loader/          # Plugin loader/runtimes
-├── registry/         # Plugin registry
-└── templates/       # Plugin templates
-```
+## Pull Request Rules
 
-### 4. Submodules (component definitions)
+- `fix/*` branches must not target `main` directly unless the PR carries the explicit
+  `layered-pr-exception` label.
+- Merge commits inside a PR branch diff are blocked by `policy-gate`.
+- Prefer a short stack over one oversized mixed PR.
+- Every PR should map to one logical lane: governance, CI/bootstrap, docs, runtime, or product.
+- Helper automation workflows are not themselves merge policy; the merge blockers should stay tied
+  to stable CI and policy jobs.
 
-```
-modules/
-├── harness_core/    # Core harness interfaces
-├── adapters/        # Adapter definitions
-├── handlers/        # Handler specs
-└── validators/      # Validation contracts
-```
+## Local Worktree Discipline
 
-### 5. Research & Analysis
+Current local work shows three relevant surfaces:
 
-```
-research/
-├── [domain]-analysis/   # Research documents
-├── [project]-specs/     # Specification documents
-└── prototypes/           # Prototype code/tests
-```
+- root checkout on `main`
+- linked worktree on `chore/governance-migration-hc`
+- clean PR-prep worktree on `chore/governance-pr-ready`
 
-## Extension Pattern
+The nested worktree path for `chore/governance-pr-ready` is awkward, but the branch itself is
+valid and currently serves as the clean isolation surface for governance-only prep.
 
-### Plugin Contract
+## Merge Exception Policy
 
-```python
-# plugins/protocol/base.py
-class Plugin(Protocol):
-    name: str
-    version: str
+The only acceptable merge exception is GitHub Actions billing or quota exhaustion where jobs never
+start. That exception still requires:
 
-    def initialize(self, config: dict) -> None: ...
-    def execute(self, ctx: Context) -> Result: ...
-    def shutdown(self) -> None: ...
-```
+- equivalent local verification
+- explicit worklog or session evidence
+- no red failing policy or test jobs
 
-### Extension Points
-
-- **codex extensions** → Extend heliosCLI
-- **harbor plugins** → Harbor framework integration
-- **portage modules** → Portage package system
-- **custom adapters** → External system connectors
-
-## Governance Rules
-
-1. **No production code** - Research/prototypes only
-2. **Clear provenance** - Document source projects
-3. **Plugin-first** - Use extension patterns over hardcoded deps
-4. **Modular** - Independent, composable components
-5. **Documented** - ADRs for architectural decisions
-
-## Directory Structure
-
-```
-heliosHarness/
-├── clones/           # Forked external projects
-├── plugins/          # Plugin system
-├── extensions/       # Extension definitions
-├── modules/          # Component interfaces
-├── research/         # Analysis documents
-├── prototypes/       # Experimental code
-├── specs/            # Specification documents
-└── artifacts/        # Generated artifacts
-```
-
-## Plugin Registry Example
-
-```yaml
-# plugins/registry.yaml
-plugins:
-  - name: codex-extension
-    type: helioscli-extension
-    source: clones/codex
-    path: extensions/codex-plugins/
-
-  - name: harbor-adapter
-    type: harbor-plugin
-    source: portage/harbor
-    path: extensions/harbor-plugins/
-```
+Failing checks, unresolved comments, and convenience bypasses are not valid exception paths.

--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -1,39 +1,43 @@
 # Worklog
 
-Active work tracking for **heliosCLI**.
+Active work tracking for `heliosCLI`.
 
----
+Updated: 2026-04-02
 
 ## Current Lanes
 
 | Lane | Branch | Worktree | Status | Notes |
 | --- | --- | --- | --- | --- |
-| Rollout limit safety fix | `fix/rollout-limit-expect` | `/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI` | Draft PR open | PR [#130](https://github.com/KooshaPari/heliosCLI/pull/130), base `main` |
-| Codex core parked work | `wip/codex-rs-core` | `/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI-wtrees/codex-rs-core` | Active | Parked WIP lane, not merged |
-| CI failures lane | `fix/ci-failures` | `/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI-wtrees/fix-ci-failures` | Active | Side lane in progress |
-| Key router decomposition | `refactor/decompose-key-router` | `/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/heliosCLI-wtrees/decompose-key-router` | Active | Refactor lane in progress |
+| Governance PR prep | `chore/governance-pr-ready` | `/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/heliosCLI/.worktrees/governance-pr-ready` | Active | Clean prep lane for repo-local governance docs and ruleset baseline |
+| Governance migration side lane | `chore/governance-migration-hc` | `/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/.worktrees/chore-govern-pi` | Clean / parked | Existing side worktree, not currently carrying new diff |
+| Canonical checkout | `main` | `/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI` | Mixed local state | Untracked nested `.worktrees/`, `docs/phenodocs/`, and accidental nested `heliosCLI/` path |
 
----
+## PR-Prep Assessment
 
-## Merged Baseline on `main`
+- The earlier story that `heliosCLI` had no active PR lane was wrong.
+- The repo does have a clean governance-only lane now, but it lives in the dedicated
+  `chore/governance-pr-ready` worktree rather than the root checkout.
+- The root checkout should not be used as the review branch because its local state is polluted by
+  nested and untracked surfaces.
 
-Recent merged commits already on `origin/main`:
+## Merge Policy Baseline
 
-1. `#126` Deprecated criterion cleanup
-2. `#128` kitty-specs to docs/specs migration
-3. `#125` rust-ci/codespell/cargo-deny fixes
-4. `#127` Additional deprecated criterion cleanup
-5. `#124` KeyEventRouter extraction refactor
+The intended merge blockers for active governance work are:
 
----
+- `policy-gate`
+- stable Rust CI jobs from `rust-ci`
+- `Stage Gates / detect-stage`
+- fast security checks from `sast-quick`
 
-## Remaining Work
+See:
 
-1. Resolve and merge draft PR `#130` (`fix/rollout-limit-expect`).
-2. Decide disposition of `wip/codex-rs-core`: split into reviewable PRs or continue as parked WIP.
-3. Finish or close `fix/ci-failures` and `refactor/decompose-key-router` lanes.
-4. Reconcile current root worktree drift (`package.json` modified) with the intended lane before further merges.
+- [../../GOVERNANCE.md](../../GOVERNANCE.md)
+- [../../.github/RULESET_BASELINE.md](../../.github/RULESET_BASELINE.md)
+- [governance/GOVERNANCE_SUMMARY.md](./governance/GOVERNANCE_SUMMARY.md)
 
----
+## Follow-Up
 
-_Last updated: 2026-03-28_
+1. Keep governance-only edits in `chore/governance-pr-ready`.
+2. Leave unrelated root-checkout untracked surfaces out of the PR.
+3. Reconcile or remove the accidental nested worktree path only after the governance PR branch is
+   safely captured elsewhere.

--- a/docs/governance/GOVERNANCE_SUMMARY.md
+++ b/docs/governance/GOVERNANCE_SUMMARY.md
@@ -1,45 +1,37 @@
-# heliosHarness Governance Summary
+# heliosCLI Governance Summary
 
-> **Status**: Research project. Production at `clones/helios-cli/`.
+> Status: Active delivery repo with workflow-backed PR policy and a documented ruleset baseline.
 
-## Project Type
+## Repo Type
 
-- **Classification**: Research/POC
-- **Production Code**: `clones/helios-cli/`
-- **This Directory**: Experiments, prototypes, benchmarks
+- Classification: active engineering repo
+- Primary branch: `main`
+- Current governance prep lane: `chore/governance-pr-ready`
+- Canonical governance files:
+  - [`GOVERNANCE.md`](../../GOVERNANCE.md)
+  - [`.github/RULESET_BASELINE.md`](../../.github/RULESET_BASELINE.md)
+  - [`.github/workflows/policy-gate.yml`](../../.github/workflows/policy-gate.yml)
 
-## Architecture
+## Active Enforcement Surface
 
-```
-heliosHarness/
-├── harness/src/harness/  # Python research
-├── crates/               # Rust experiments  
-├── clones/               # Reference implementations
-│   └── helios-cli/       # PRODUCTION
-└── docs/                # Research docs
-```
+- `policy-gate` blocks direct `fix/* -> main` PRs unless explicitly exempted
+- `policy-gate` blocks merge commits in PR diff ranges
+- `rust-ci` provides the main Rust build and drift checks
+- `stage-gates` adds branch-class-based gate expectations
+- `sast-quick` provides fast security and secret-scan coverage on PRs
 
-## Governance
+## Current PR-Prep Reality
 
-Since this is a research project:
-- Lighter governance than production
-- Focus on experimentation and learning
-- Production rules apply in `clones/helios-cli/`
+- root checkout is on `main`
+- linked worktree `chore/governance-migration-hc` is clean
+- clean PR-prep branch `chore/governance-pr-ready` is the intended governance-only lane
+- root checkout still carries untracked nested surfaces, so PR prep should stay isolated to the
+  dedicated worktree branch
 
-## Commands
+## Immediate Next Step
 
-```bash
-# Python research
-task py:test
+Use `chore/governance-pr-ready` to ship only:
 
-# Rust experiments
-task rust:test
-
-# Check
-task check
-```
-
-## References
-
-- Production: `clones/helios-cli/`
-- Taskfile: Standard (see Taskfile.yml)
+1. corrected governance docs
+2. ruleset baseline documentation
+3. any minimal CI-policy wiring needed to make the branch reviewable

--- a/docs/sessions/2026-04-02-governance-pr-prep/01_RESEARCH.md
+++ b/docs/sessions/2026-04-02-governance-pr-prep/01_RESEARCH.md
@@ -1,0 +1,21 @@
+# Research
+
+## Live repo state
+
+- root checkout branch: `main`
+- linked worktree: `chore/governance-migration-hc`
+- clean PR-prep worktree: `chore/governance-pr-ready`
+- root checkout is not PR-clean because it shows untracked nested surfaces
+
+## Governance evidence used
+
+- `policy-gate.yml` exists and runs on pull requests
+- composite `policy-gate` action exists under `.github/actions/policy-gate/action.yml`
+- `rust-ci.yml` provides the main Rust drift/build jobs
+- `stage-gates.yml` runs on pull requests and adds branch-class policy
+- `sast-quick.yml` provides fast Semgrep, secret scan, lint, and license checks
+
+## Key correction
+
+The tracked governance docs were stale and still described `heliosHarness` as a research repo.
+That did not match the actual project identity or the workflow surface present in this checkout.

--- a/docs/sessions/2026-04-02-governance-pr-prep/02_PLAN.md
+++ b/docs/sessions/2026-04-02-governance-pr-prep/02_PLAN.md
@@ -1,0 +1,7 @@
+# Plan
+
+1. Correct repo identity in governance docs.
+2. Add a repo-local ruleset baseline that can be synced into GitHub settings later.
+3. Update the worklog so the governance PR-prep lane points to the clean worktree, not the dirty
+   root checkout.
+4. Validate the referenced workflow files still parse and exist.

--- a/docs/sessions/2026-04-02-governance-pr-prep/03_IMPLEMENTATION.md
+++ b/docs/sessions/2026-04-02-governance-pr-prep/03_IMPLEMENTATION.md
@@ -1,0 +1,11 @@
+# Implementation
+
+Updated these repo-local control surfaces in the clean `chore/governance-pr-ready` worktree:
+
+- `GOVERNANCE.md`
+- `.github/RULESET_BASELINE.md`
+- `docs/governance/GOVERNANCE_SUMMARY.md`
+- `docs/WORKLOG.md`
+
+The changes intentionally stayed documentation-only so this branch can become a reviewable
+governance baseline without mixing in unrelated runtime or product churn.

--- a/docs/sessions/2026-04-02-governance-pr-prep/04_VALIDATION.md
+++ b/docs/sessions/2026-04-02-governance-pr-prep/04_VALIDATION.md
@@ -1,0 +1,12 @@
+# Validation
+
+Validated against the live workflow surface referenced by the docs:
+
+- `.github/workflows/policy-gate.yml`
+- `.github/actions/policy-gate/action.yml`
+- `.github/workflows/rust-ci.yml`
+- `.github/workflows/stage-gates.yml`
+- `.github/workflows/sast-quick.yml`
+
+The branch also remains isolated from the dirty root checkout because the edits live in the
+dedicated `chore/governance-pr-ready` worktree.

--- a/docs/sessions/2026-04-02-governance-pr-prep/05_KNOWN_ISSUES.md
+++ b/docs/sessions/2026-04-02-governance-pr-prep/05_KNOWN_ISSUES.md
@@ -1,0 +1,9 @@
+# Known Issues
+
+- The `chore/governance-pr-ready` worktree was created at an awkward nested path under
+  `heliosCLI/heliosCLI/.worktrees/`. The branch is usable, but the path should be normalized after
+  the governance lane is safely captured.
+- The root checkout is still polluted by untracked nested surfaces and should not be used as the
+  PR branch.
+- This branch documents the intended ruleset posture, but remote GitHub protection settings still
+  need a separate sync pass.

--- a/docs/sessions/2026-04-02-governance-pr-prep/README.md
+++ b/docs/sessions/2026-04-02-governance-pr-prep/README.md
@@ -1,0 +1,19 @@
+# heliosCLI governance PR prep
+
+## Goal
+
+Prepare a clean, reviewable governance-only lane for `heliosCLI` by correcting stale control
+surfaces and documenting the intended repo ruleset posture.
+
+## Scope
+
+- repo-local governance docs
+- ruleset baseline documentation
+- worklog correction for the active PR-prep lane
+- validation of existing workflow-backed policy surfaces
+
+## Out of Scope
+
+- root-checkout untracked cleanup
+- unrelated product/runtime edits
+- remote GitHub settings mutation


### PR DESCRIPTION
## Summary
- replace stale heliosHarness governance framing with heliosCLI-specific repo governance docs
- add a checked-in RULESET baseline for the intended protected-main posture
- publish the governance PR-prep session bundle and corrected worklog/governance summary surfaces

## Validation
- reviewed repo-local governance docs and branch/worktree posture
- kept this lane docs-only and separate from the existing governance workflow branch

## Notes
- this is intentionally separate from PR #182 because it carries governance documentation and ruleset-baseline surfaces that were still stranded in the nested worktree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated governance documentation to reflect delivery-focused repository policies and branch protection requirements.
  * Added GitHub ruleset baseline configuration documentation.
  * Updated worklog with current governance-focused development lanes and validation notes.

* **Chores**
  * Reorganized internal governance and policy documentation for repository maintenance clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->