### PR TITLE
fix(readme): correct workspace crate count to match Cargo.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,10 @@ heliosCLI is organized as **two Rust workspaces**:
 
 ### Root Workspace (`./Cargo.toml`)
 
-The root workspace contains the **heliosHarness** system — a collection of 18 crates providing validation, caching, checkpointing, discovery, orchestration, and resilience for autonomous agent operations.
+The root workspace contains the **heliosHarness** system — a collection of 9 crates providing validation, orchestration, and resilience for autonomous agent operations.
 
 ```
 crates/
-├── harness_cache/          # Persistent caching layer
-├── harness_checkpoint/     # State checkpointing and recovery
-├── harness_discoverer/     # Task and capability discovery
-├── harness_elicitation/    # User input elicitation
-├── harness_interfaces/     # Shared trait definitions
-├── harness_normalizer/     # Input/output normalization
-├── harness_orchestrator/   # Sub-agent orchestration
-├── harness_pyo3/           # Python interop bindings
 ├── harness_queue/          # Task queue management
 ├── harness_rollback/       # Rollback and undo support
 ├── harness_runner/         # Task execution runner
@@ -34,6 +26,8 @@ crates/
 ├── harness_utils/          # Shared utilities
 └── harness_verify/         # Verification and validation
 ```
+
+**Note:** Additional crates in `crates/` (harness_cache, harness_checkpoint, harness_discoverer, harness_elicitation, harness_interfaces, harness_normalizer, harness_orchestrator, harness_pyo3, harness_mojo, harness_zig, thegent-*, adrs, api, arch_test, changes, governance) are utility, documentation, or test crates not included in the root workspace members list.
 
 ### Helios Workspace (`helios-rs/Cargo.toml`)
 


### PR DESCRIPTION
## **User description**
Audit found README claimed 18 crates in root workspace, but Cargo.toml only defines 9 workspace members.

**Changes:**
- Updated crate list from 18 to 9
- Listed only actual workspace members (harness_queue, harness_rollback, harness_runner, harness_scaling, harness_schema, harness_spec, harness_teammates, harness_utils, harness_verify)
- Added note documenting additional utility/test crates in `crates/` that are not workspace members

**Reference:** repos/docs/governance/userstory-tier1-reverify-2026-04-26.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that update workspace crate counts/lists; no runtime or build behavior is modified.
> 
> **Overview**
> Corrects the README’s root workspace description to match `Cargo.toml` by changing the `heliosHarness` member count from 18 to 9 and listing only the actual workspace member crates.
> 
> Adds a note clarifying that other crates under `crates/` exist but are not included in the root workspace members list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4871a9f31a6c02c7cca0782fb4f23e9e5542c762. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Correct the root workspace crate list in the README**

### What Changed
- Updated the root workspace count from 18 crates to 9 to match the actual workspace definition
- Removed non-workspace crates from the main crate list and kept only the real root workspace members
- Added a note explaining that other crates under `crates/` are utility, documentation, or test crates and are not part of the root workspace

### Impact
`✅ Clearer workspace documentation`
`✅ Fewer mismatches between README and Cargo.toml`
`✅ Easier crate discovery for contributors`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=l0VIMwR_uDAv4H45IBdM0WvfWkkMAJLjcbb9wUtFRqc&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
