### PR TITLE
chore(gitignore): add .worktrees/ + .claude/worktrees/ entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,7 @@ CHANGELOG.ignore.md
 __pycache__/
 *.pyc
 
+
+# Worktree directories (org policy)
+.worktrees/
+.claude/worktrees/


### PR DESCRIPTION
Per worktree-gitignore-coverage audit (2026-04-26).

Prevents phantom-gitlinks pattern by ensuring both worktree directory patterns are properly ignored.

Ref: repos/docs/governance/worktree-gitignore-coverage-2026-04-26.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `.gitignore` to exclude additional local/worktree directories and does not affect runtime code or build behavior.
> 
> **Overview**
> Updates `.gitignore` to ignore org-standard worktree directories by adding `.worktrees/` and `.claude/worktrees/`, preventing these local worktree artifacts from being accidentally tracked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79dceaae651731577800534e3c8a7b37561c2550. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->