### PR TITLE
Fix stage gates workflow syntax

### DIFF
--- a/.github/workflows/stage-gates.yml
+++ b/.github/workflows/stage-gates.yml
@@ -16,8 +16,7 @@ env:
 
 jobs:
   detect-stage:
-    runs-on:
-  workflow_dispatch: ubuntu-latest
+    runs-on: ubuntu-latest
     outputs:
       stage: ${{ steps.detect.outputs.stage }}
       gates: ${{ steps.detect.outputs.gates }}
@@ -94,8 +93,7 @@ jobs:
   format-check:
     needs: detect-stage
     if: contains(needs.detect-stage.outputs.gates, 'format')
-    runs-on:
-  workflow_dispatch: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Format check (Rust)
@@ -114,8 +112,7 @@ jobs:
   lint:
     needs: detect-stage
     if: contains(needs.detect-stage.outputs.gates, 'lint')
-    runs-on:
-  workflow_dispatch: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install Linux build dependencies (Rust)
@@ -139,8 +136,7 @@ jobs:
   secret-scan:
     needs: detect-stage
     if: contains(needs.detect-stage.outputs.gates, 'secrets')
-    runs-on:
-  workflow_dispatch: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -155,8 +151,7 @@ jobs:
   unit-tests:
     needs: detect-stage
     if: contains(needs.detect-stage.outputs.gates, 'unit')
-    runs-on:
-  workflow_dispatch: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install Linux build dependencies (Rust)
@@ -180,8 +175,7 @@ jobs:
   integration-tests:
     needs: detect-stage
     if: contains(needs.detect-stage.outputs.gates, 'integration')
-    runs-on:
-  workflow_dispatch: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install Linux build dependencies (Rust)
@@ -205,8 +199,7 @@ jobs:
   coverage-check:
     needs: detect-stage
     if: contains(needs.detect-stage.outputs.gates, 'coverage-')
-    runs-on:
-  workflow_dispatch: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install Linux build dependencies (Rust)
@@ -248,8 +241,7 @@ jobs:
   sast-scan:
     needs: detect-stage
     if: contains(needs.detect-stage.outputs.gates, 'sast')
-    runs-on:
-  workflow_dispatch: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: SAST (Rust)
@@ -268,8 +260,7 @@ jobs:
   dependency-audit:
     needs: detect-stage
     if: contains(needs.detect-stage.outputs.gates, 'dep-audit')
-    runs-on:
-  workflow_dispatch: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Dep audit (Rust)
@@ -287,9 +278,8 @@ jobs:
 
   license-check:
     needs: detect-stage
-    if: contains(needs.detect-stage.outputs.gates, 'license') && secrets.FOSSA_API_KEY != ''
-    runs-on:
-  workflow_dispatch: ubuntu-latest
+    if: contains(needs.detect-stage.outputs.gates, 'license')
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: License scan
@@ -300,8 +290,7 @@ jobs:
   e2e-smoke:
     needs: detect-stage
     if: contains(needs.detect-stage.outputs.gates, 'e2e-smoke')
-    runs-on:
-  workflow_dispatch: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Run smoke E2E tests
@@ -315,8 +304,7 @@ jobs:
   e2e-full:
     needs: detect-stage
     if: contains(needs.detect-stage.outputs.gates, 'e2e-full')
-    runs-on:
-  workflow_dispatch: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Run full E2E tests
@@ -330,8 +318,7 @@ jobs:
   perf-benchmark:
     needs: detect-stage
     if: contains(needs.detect-stage.outputs.gates, 'perf')
-    runs-on:
-  workflow_dispatch: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Run performance benchmarks
@@ -343,11 +330,9 @@ jobs:
           fi
 
   sla-validation:
-  workflow_dispatch:
     needs: detect-stage
     if: contains(needs.detect-stage.outputs.gates, 'sla-validation')
-    runs-on:
-  workflow_dispatch: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Validate SLA compliance
@@ -361,8 +346,7 @@ jobs:
   coderabbit:
     needs: detect-stage
     if: contains(needs.detect-stage.outputs.gates, 'coderabbit')
-    runs-on:
-  workflow_dispatch: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Trigger CodeRabbit review
@@ -375,8 +359,7 @@ jobs:
   gca-review:
     needs: detect-stage
     if: contains(needs.detect-stage.outputs.gates, 'gca-review')
-    runs-on:
-  workflow_dispatch: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: GCA review gate
@@ -385,8 +368,7 @@ jobs:
   manual-security:
     needs: detect-stage
     if: contains(needs.detect-stage.outputs.gates, 'manual-security')
-    runs-on:
-  workflow_dispatch: ubuntu-latest
+    runs-on: ubuntu-latest
     environment: security-review
     steps:
       - name: Manual security review gate
@@ -395,8 +377,7 @@ jobs:
   sbom:
     needs: detect-stage
     if: contains(needs.detect-stage.outputs.gates, 'sbom')
-    runs-on:
-  workflow_dispatch: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Generate SBOM
@@ -407,8 +388,7 @@ jobs:
   artifact-checksum:
     needs: detect-stage
     if: contains(needs.detect-stage.outputs.gates, 'artifact-checksum')
-    runs-on:
-  workflow_dispatch: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Build and checksum artifacts
@@ -427,11 +407,9 @@ jobs:
           path: checksums.sha256
 
   targeted-regression:
-  workflow_dispatch:
     needs: detect-stage
     if: contains(needs.detect-stage.outputs.gates, 'targeted-regression')
-    runs-on:
-  workflow_dispatch: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Run targeted regression tests


### PR DESCRIPTION
## **User description**
## Summary
- repair corrupted `runs-on` entries in `stage-gates.yml`
- restore `sla-validation` and `targeted-regression` as real job keys
- remove invalid job-level `secrets.*` expression from the license gate

## Validation
- actionlint .github/workflows/stage-gates.yml
- git diff --check

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk YAML/syntax fixes to a GitHub Actions workflow; main impact is which CI gates run (not application/runtime behavior).
> 
> **Overview**
> Repairs the `Stage Gates` GitHub Actions workflow by fixing corrupted `runs-on` entries and restoring `sla-validation` and `targeted-regression` as proper jobs.
> 
> Updates the `license-check` gate to remove an invalid job-level `secrets.*` condition, so the job is selected purely by the detected gate list (while still passing `FOSSA_API_KEY` to the action).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21c86ff8fd53b92c822335cfbf86f7cdeaaa7e96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Fix the Stage Gates workflow so its checks can run again

### What Changed
- Restored the workflow’s job syntax so GitHub can parse and schedule the stage gates again
- Fixed broken job names for SLA validation and targeted regression so those gates appear and run as expected
- Removed the license gate’s secret check from the job condition, so license scanning is selected by the gate list and still receives the FOSSA key when it runs

### Impact
`✅ Stage gate checks run again`
`✅ Fewer missing CI jobs`
`✅ Clearer license scan behavior`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=GcrsK8YAGn2aqK3gCkSjo8IJd0nO1zhxTqv88f9lUVQ&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
