### PR TITLE
ci: add CodeQL Rust analysis (security scanning)

### DIFF
--- a/.github/workflows/codeql-rust.yml
+++ b/.github/workflows/codeql-rust.yml
@@ -1,0 +1,33 @@
+name: CodeQL (Rust)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '17 4 * * 2'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze (rust)
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: rust
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:rust"


### PR DESCRIPTION
## Summary

Adds GitHub CodeQL analysis for Rust code in heliosCLI.

## Details

- Runs CodeQL on pushes and pull requests targeting main.
- Adds a weekly Tuesday scheduled scan.
- Keeps manual workflow dispatch enabled for on-demand security analysis.

## Validation

- Verified the workflow file is the only staged change in this branch.
