### PR TITLE
ci: fix codespell configuration

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -6,3 +6,4 @@ TE
 other
 level
 node_modules
+unparseable

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git*,vendor,*-lock.yaml,*.lock,.codespellrc,*test.ts,*.jsonl,frame*.txt,*.snap,*.snap.new,*meriyah.umd.min.js,perf-results,rust_core,assets,*.js,.archive,worktrees
+skip = .git*,vendor,*-lock.yaml,*.lock,.codespellrc,*test.ts,*.jsonl,frame*.txt,*.snap,*.snap.new,*meriyah.umd.min.js,perf-results,rust_core,assets,*.js,.archive,worktrees,fragemented
 check-hidden = true
 ignore-regex = ^\s*"image/\S+": ".*|\b(afterAll)\b
 ignore-words-list = ratatui,ser,iTerm,iterm2,iterm,te,TE,inout,suports,surpressed

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -24,4 +24,5 @@ jobs:
       - name: Codespell
         uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2
         with:
+          config: .codespellrc
           ignore_words_file: .codespellignore


### PR DESCRIPTION
## **User description**
## Summary
- pass `.codespellrc` into the Codespell GitHub Action
- skip generated `fragemented/` HTML output through repo config
- add the existing `_typos.toml` project word `unparseable` to Codespell ignores

Fixes #72

## Validation
- `uvx codespell --config .codespellrc --ignore-words .codespellignore`
- `uvx codespell --config .codespellrc --ignore-words .codespellignore --skip ./.git`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adjusts how codespell runs and what it ignores; no production code paths are affected.
> 
> **Overview**
> Ensures the GitHub Actions `codespell` job actually uses the repository’s `.codespellrc` by passing it via the action input.
> 
> Updates codespell exclusions by adding `fragemented` to the configured `skip` list and adds `unparseable` to `.codespellignore` to prevent false positives in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 981f11de769ba57064c4c55a20804f4bd93d1b4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Fix codespell checks so they respect the repo’s spelling rules**

### What Changed
- Codespell now uses the repository’s shared configuration during CI, so the spelling check matches local runs
- The generated `fragemented/` output is now skipped during spelling checks
- `unparseable` is added to the spelling ignore list to avoid a false positive

### Impact
`✅ Fewer false spelling failures in CI`
`✅ Consistent spelling checks between local and GitHub Actions`
`✅ Less noise from generated content`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=KeoSH4vsjXOpu9_yj238mT-pNLSdmherUrRdLMYZ7ro&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
