### PR TITLE
ci: refresh ZAP release download

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -13,15 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
         with:
+          persist-credentials: false
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
           java-version: '17'
       - name: Install SonarScanner
         run: |
           curl -sSfL https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.9.0.2725-linux.zip -o sonar.zip
           unzip sonar.zip
-          export PATH=$PATH:$PWD/sonar-scanner-4.9.0.2725/bin
+          echo "$PWD/sonar-scanner-4.9.0.2725/bin" >> "$GITHUB_PATH"
       - name: Run SonarCloud
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/zap-dast.yml
+++ b/.github/workflows/zap-dast.yml
@@ -14,9 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install ZAP
         run: |
-          wget https://github.com/zaproxy/zap-full-bin/releases/download/2.15.0/zap-full-linux-amd64.tar.gz
+          wget -O zap-full-linux-amd64.tar.gz \
+            https://github.com/zaproxy/zap-full-bin/releases/latest/download/zap-full-linux-amd64.tar.gz
           tar -xzf zap-full-linux-amd64.tar.gz
           mv zap-full-linux-amd64 zap
       - name: Run ZAP

--- a/docs/sessions/20260427-sonarcloud-setup-java-fix/01_RESEARCH.md
+++ b/docs/sessions/20260427-sonarcloud-setup-java-fix/01_RESEARCH.md
@@ -1,0 +1,13 @@
+# Research
+
+## Live evidence
+
+- Issue `#181` points to run `24937041945` and reports `SonarCloud failing on main`.
+- The failing log shows `actions/setup-java@v3` with `Input required and not supplied: distribution`.
+- The workflow also uses a transient `export PATH=...` in the scanner install step, which does not survive into the next GitHub Actions step.
+- The repo already uses `persist-credentials: false` in `.github/workflows/scorecard.yml`.
+
+## Decision
+
+Use `distribution: temurin` with `actions/setup-java@v4`, and write the SonarScanner bin
+directory to `GITHUB_PATH` so the next step can invoke `sonar-scanner`.

--- a/docs/sessions/20260427-sonarcloud-setup-java-fix/02_PLAN.md
+++ b/docs/sessions/20260427-sonarcloud-setup-java-fix/02_PLAN.md
@@ -1,0 +1,6 @@
+# Plan
+
+1. Inspect the failing SonarCloud workflow and its run log.
+2. Align the workflow with the repo's existing checkout and Java setup patterns.
+3. Patch the scanner install path so it survives step boundaries.
+4. Validate the YAML and land the fix.

--- a/docs/sessions/20260427-sonarcloud-setup-java-fix/03_IMPLEMENTATION.md
+++ b/docs/sessions/20260427-sonarcloud-setup-java-fix/03_IMPLEMENTATION.md
@@ -1,0 +1,10 @@
+# Implementation
+
+The workflow now uses:
+
+- `actions/checkout@v4` with `persist-credentials: false`
+- `actions/setup-java@v4` with `distribution: temurin` and Java 17
+- `GITHUB_PATH` to expose the downloaded SonarScanner bin directory to later steps
+
+These changes keep the job simple and avoid the two failure modes visible in the run log:
+the missing setup-java distribution input and the non-persistent PATH export.

--- a/docs/sessions/20260427-sonarcloud-setup-java-fix/04_VALIDATION.md
+++ b/docs/sessions/20260427-sonarcloud-setup-java-fix/04_VALIDATION.md
@@ -1,0 +1,11 @@
+# Validation
+
+## Expected checks
+
+- Workflow file parses as YAML.
+- The workflow contains `distribution: temurin`.
+- The scanner install step writes to `GITHUB_PATH`.
+
+## Follow-up
+
+- Merge the PR and verify the alert-sync issue auto-closes or close it manually if the repository automation lags.

--- a/docs/sessions/20260427-sonarcloud-setup-java-fix/05_KNOWN_ISSUES.md
+++ b/docs/sessions/20260427-sonarcloud-setup-java-fix/05_KNOWN_ISSUES.md
@@ -1,0 +1,5 @@
+# Known issues
+
+- The archived worktree/submodule cleanup warning may still appear in historical logs, but
+  the workflow patch removes the first concrete blocker and reduces checkout cleanup risk.
+- Final closure depends on the PR merge and GitHub's alert-sync timing.

--- a/docs/sessions/20260427-sonarcloud-setup-java-fix/README.md
+++ b/docs/sessions/20260427-sonarcloud-setup-java-fix/README.md
@@ -1,0 +1,18 @@
+# SonarCloud workflow fix
+
+## Goal
+
+Fix the `SonarCloud failing on main` alert by repairing the GitHub Actions workflow in
+`.github/workflows/sonarcloud.yml`.
+
+## Scope
+
+- Add the required Java distribution input to `actions/setup-java`.
+- Make the scanner path persist across workflow steps.
+- Reduce checkout cleanup risk in a repo with archived worktree baggage.
+
+## Success criteria
+
+- Workflow YAML is valid.
+- The SonarCloud job can reach the scanner step.
+- The alert-sync issue can be closed after the patch is merged.

--- a/docs/sessions/20260427-zap-dast-download-fix/01_RESEARCH.md
+++ b/docs/sessions/20260427-zap-dast-download-fix/01_RESEARCH.md
@@ -1,0 +1,13 @@
+# Research
+
+## Live evidence
+
+- Issue `#186` points to run `24918681199`.
+- The failed log shows `wget .../releases/download/2.15.0/zap-full-linux-amd64.tar.gz` returning `404 Not Found`.
+- The same checkout cleanup warning appears after the failed step because the repo has archived
+  submodule/worktree baggage.
+
+## Decision
+
+Use the latest release asset path from GitHub Releases instead of a pinned versioned URL, and
+disable persisted checkout credentials to reduce cleanup friction.

--- a/docs/sessions/20260427-zap-dast-download-fix/02_PLAN.md
+++ b/docs/sessions/20260427-zap-dast-download-fix/02_PLAN.md
@@ -1,0 +1,6 @@
+# Plan
+
+1. Confirm the failing download URL from the run log.
+2. Patch the workflow to fetch the current ZAP release asset path.
+3. Disable persisted checkout credentials to reduce cleanup noise.
+4. Validate the YAML and land the fix.

--- a/docs/sessions/20260427-zap-dast-download-fix/03_IMPLEMENTATION.md
+++ b/docs/sessions/20260427-zap-dast-download-fix/03_IMPLEMENTATION.md
@@ -1,0 +1,8 @@
+# Implementation
+
+The workflow now:
+
+- uses `actions/checkout@v4` with `persist-credentials: false`
+- downloads ZAP from `releases/latest/download/zap-full-linux-amd64.tar.gz`
+
+This removes the pinned dead asset URL that caused the current main failure.

--- a/docs/sessions/20260427-zap-dast-download-fix/04_VALIDATION.md
+++ b/docs/sessions/20260427-zap-dast-download-fix/04_VALIDATION.md
@@ -1,0 +1,11 @@
+# Validation
+
+## Expected checks
+
+- Workflow YAML parses.
+- The `wget` command points at the latest release download URL.
+- Checkout credentials are not persisted.
+
+## Follow-up
+
+- Re-run or observe the GitHub Actions alert after merge to confirm the failure mode moved past the dead download.

--- a/docs/sessions/20260427-zap-dast-download-fix/05_KNOWN_ISSUES.md
+++ b/docs/sessions/20260427-zap-dast-download-fix/05_KNOWN_ISSUES.md
@@ -1,0 +1,4 @@
+# Known issues
+
+- The workflow still scans `http://localhost:8080`; if the next run exposes a target-startup problem,
+  it will need a follow-on fix.

--- a/docs/sessions/20260427-zap-dast-download-fix/README.md
+++ b/docs/sessions/20260427-zap-dast-download-fix/README.md
@@ -1,0 +1,16 @@
+# ZAP DAST workflow fix
+
+## Goal
+
+Fix the `ZAP DAST failing on main` alert by repairing the GitHub Actions workflow in
+`.github/workflows/zap-dast.yml`.
+
+## Scope
+
+- Stop pinning a dead ZAP release asset URL.
+- Reduce checkout cleanup risk with archived submodule/worktree baggage.
+
+## Success criteria
+
+- Workflow can download the scanner bundle again.
+- The alert-sync issue can be re-evaluated after the patch is merged.


### PR DESCRIPTION
## **User description**
Fixes #186

- stop pinning the dead `2.15.0` ZAP asset URL
- download ZAP from `releases/latest/download` so the workflow tracks the current release
- disable persisted checkout credentials to reduce cleanup friction

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions workflow configuration and documentation, mainly to unblock failing CI runs; primary risk is CI behavior changing due to tracking ZAP `releases/latest`.
> 
> **Overview**
> Fixes failing security/quality CI workflows by updating GitHub Actions configuration.
> 
> `sonarcloud.yml` now uses `actions/setup-java@v4` with `distribution: temurin`, disables persisted checkout credentials, and makes the SonarScanner binary available across steps via `GITHUB_PATH`.
> 
> `zap-dast.yml` disables persisted checkout credentials and switches the ZAP download from a pinned (now 404) versioned URL to `releases/latest/download`. Adds session docs capturing research/plan/validation for both fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f73329bd94fb970a8b1bf6fbe127df05ab5a13e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Fix failing SonarCloud and ZAP DAST workflows

### What Changed
- SonarCloud now sets the required Java distribution, keeps the scanner available for later steps, and avoids checkout credential cleanup issues
- ZAP DAST now downloads the scanner bundle from the current GitHub release instead of a dead versioned URL
- Both workflows disable persisted checkout credentials to reduce cleanup friction in CI runs

### Impact
`✅ Fewer CI failures on main`
`✅ Clearer SonarCloud job runs`
`✅ Restored ZAP security scan downloads`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=uw1USdioRclkBswTXZoVIb_pNBjaGcUcLUCHxXoa_zc&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
